### PR TITLE
Memoize filesystem operations during unpack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ contents are never required to be entirely resident in memory all at once.
 filetime = "0.2"
 futures-core = "0.3"
 portable-atomic = "1"
+rustc-hash = "2.1.0"
 tokio = { version = "1", features = ["fs", "io-util", "rt"] }
 tokio-stream = "0.1"
 


### PR DESCRIPTION
## Summary

The `dst` is the same throughout the life of the unpack, and we canonicalize it _before_ unpacking. So we can avoid re-validating and re-canonicalizing for every single archive entry.

For a large PyTorch wheel, this improves performance by about 12.5%.
