### PR TITLE
Rename `unpack_in_memo` to `unpack_in_raw`

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -252,7 +252,7 @@ impl<R: Read + Unpin> Archive<R> {
             if file.header().entry_type() == crate::EntryType::Directory {
                 directories.push(file);
             } else {
-                file.unpack_in_memo(&dst, &mut targets).await?;
+                file.unpack_in_raw(&dst, &mut targets).await?;
             }
         }
 
@@ -265,7 +265,7 @@ impl<R: Read + Unpin> Archive<R> {
         // [0]: <https://github.com/alexcrichton/tar-rs/issues/242>
         directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
         for mut dir in directories {
-            dir.unpack_in_memo(&dst, &mut targets).await?;
+            dir.unpack_in_raw(&dst, &mut targets).await?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

If this is gonna be on `crates.io`, I want this method to be named in a way that connotes some of the danger. I've also changed `pub async fn unpack_in` to perform the canonicalize, so anyone using that (existing) API is protected from the canonicalization.