### PR TITLE
Restore create_dir_all method for directory creation

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -907,7 +907,7 @@ impl<R: Read + Unpin> EntryFields<R> {
             if let Some(parent) = ancestor.parent() {
                 self.validate_inside_dst(dst, parent).await?;
             }
-            fs::create_dir(ancestor).await?;
+            fs::create_dir_all(ancestor).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Ports https://github.com/alexcrichton/tar-rs/pull/260 to the `async-tar` crate.