### PR TITLE
Avoid reallocating Strings when creating `TarError`

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -230,7 +230,7 @@ impl<R: Read + Unpin> Archive<R> {
         if fs::symlink_metadata(dst).await.is_err() {
             fs::create_dir_all(&dst)
                 .await
-                .map_err(|e| TarError::new(&format!("failed to create `{}`", dst.display()), e))?;
+                .map_err(|e| TarError::new(format!("failed to create `{}`", dst.display()), e))?;
         }
 
         // Canonicalizing the dst directory will prepend the path with '\\?\'

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -474,7 +474,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         {
             let path = self.path().map_err(|e| {
                 TarError::new(
-                    &format!("invalid path in entry header: {}", self.path_lossy()),
+                    format!("invalid path in entry header: {}", self.path_lossy()),
                     e,
                 )
             })?;
@@ -511,7 +511,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         // Validate the parent, if we haven't seen it yet.
         if !memo.contains(parent) {
             self.ensure_dir_created(dst, parent).await.map_err(|e| {
-                TarError::new(&format!("failed to create `{}`", parent.display()), e)
+                TarError::new(format!("failed to create `{}`", parent.display()), e)
             })?;
             self.validate_inside_dst(dst, parent).await?;
             memo.insert(parent.to_path_buf());
@@ -519,7 +519,7 @@ impl<R: Read + Unpin> EntryFields<R> {
 
         self.unpack(Some(dst), &file_dst)
             .await
-            .map_err(|e| TarError::new(&format!("failed to unpack `{}`", file_dst.display()), e))?;
+            .map_err(|e| TarError::new(format!("failed to unpack `{}`", file_dst.display()), e))?;
 
         Ok(Some(file_dst))
     }
@@ -756,7 +756,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         .map_err(|e| {
             let header = self.header.path_bytes();
             TarError::new(
-                &format!(
+                format!(
                     "failed to unpack `{}` into `{}`",
                     String::from_utf8_lossy(&header),
                     dst.display()
@@ -769,7 +769,7 @@ impl<R: Read + Unpin> EntryFields<R> {
             if let Ok(mtime) = self.header.mtime() {
                 let mtime = FileTime::from_unix_time(mtime as i64, 0);
                 filetime::set_file_times(dst, mtime, mtime).map_err(|e| {
-                    TarError::new(&format!("failed to set mtime for `{}`", dst.display()), e)
+                    TarError::new(format!("failed to set mtime for `{}`", dst.display()), e)
                 })?;
             }
         }
@@ -790,7 +790,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         ) -> Result<(), TarError> {
             _set_perms(dst, f, mode).await.map_err(|e| {
                 TarError::new(
-                    &format!(
+                    format!(
                         "failed to set permissions to {:o} \
                          for `{}`",
                         mode,
@@ -864,7 +864,7 @@ impl<R: Read + Unpin> EntryFields<R> {
             for (key, value) in exts {
                 xattr::set(dst, key, value).map_err(|e| {
                     TarError::new(
-                        &format!(
+                        format!(
                             "failed to set extended \
                              attributes to {}. \
                              Xattrs: key={:?}, value={:?}.",
@@ -922,7 +922,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         })?;
         if !canon_parent.starts_with(dst) {
             let err = TarError::new(
-                &format!(
+                format!(
                     "trying to unpack outside of destination path: {}",
                     dst.display()
                 ),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,18 @@
-use std::{error, fmt};
-
-use tokio::io::{self, Error};
+use std::borrow::Cow;
+use std::error;
+use std::fmt;
+use std::io::{self, Error};
 
 #[derive(Debug)]
 pub struct TarError {
-    desc: String,
+    desc: Cow<'static, str>,
     io: io::Error,
 }
 
 impl TarError {
-    pub fn new(desc: &str, err: Error) -> TarError {
+    pub fn new(desc: impl Into<Cow<'static, str>>, err: Error) -> TarError {
         TarError {
-            desc: desc.to_string(),
+            desc: desc.into(),
             io: err,
         }
     }


### PR DESCRIPTION
## Summary

Ports https://github.com/alexcrichton/tar-rs/pull/269 to `async-tar`.
