### PR TITLE
Update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/tokio-tar"
 license = "MIT/Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 exclude = ["tests/archives/*"]
 
 description = """


### PR DESCRIPTION
## Summary

Ports https://github.com/alexcrichton/tar-rs/pull/362 to `async-tar`.