### PR TITLE
fix for archiving long paths that have path components starting with ".." crossing the 100-character mark

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,8 +1,8 @@
 use crate::{
-    header::{bytes2path, path2bytes, HeaderMode},
+    header::{path2bytes, HeaderMode},
     other, EntryType, Header,
 };
-use std::{borrow::Cow, fs::Metadata, path::Path};
+use std::{fs::Metadata, path::Path, str};
 use tokio::{
     fs,
     io::{self, AsyncRead as Read, AsyncReadExt, AsyncWrite as Write, AsyncWriteExt},
@@ -566,10 +566,17 @@ async fn prepare_header_path<Dst: Write + Unpin + ?Sized>(
         // null-terminated string
         let mut data2 = data.chain(io::repeat(0).take(1));
         append(dst, &header2, &mut data2).await?;
+
         // Truncate the path to store in the header we're about to emit to
-        // ensure we've got something at least mentioned.
-        let path = bytes2path(Cow::Borrowed(&data[..max]))?;
-        header.set_path(&path)?;
+        // ensure we've got something at least mentioned. Note that we use
+        // `str`-encoding to be compatible with Windows, but in general the
+        // entry in the header itself shouldn't matter too much since extraction
+        // doesn't look at it.
+        let truncated = match str::from_utf8(&data[..max]) {
+            Ok(s) => s,
+            Err(e) => str::from_utf8(&data[..e.valid_up_to()]).unwrap(),
+        };
+        header.set_truncated_path_for_gnu_header(truncated)?;
     }
     Ok(())
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -363,14 +363,33 @@ impl Header {
     /// in the appropriate format. May fail if the path is too long or if the
     /// path specified is not Unicode and this is a Windows platform.
     pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
-        self._set_path(p.as_ref())
+        self.set_path_inner(p.as_ref(), false)
     }
 
-    fn _set_path(&mut self, path: &Path) -> io::Result<()> {
+    // Sets the truncated path for GNU header
+    //
+    // Same as set_path but skips some validations.
+    pub(crate) fn set_truncated_path_for_gnu_header<P: AsRef<Path>>(
+        &mut self,
+        p: P,
+    ) -> std::io::Result<()> {
+        self.set_path_inner(p.as_ref(), true)
+    }
+
+    fn set_path_inner(
+        &mut self,
+        path: &Path,
+        is_truncated_gnu_long_path: bool,
+    ) -> std::io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
             return ustar.set_path(path);
         }
-        copy_path_into(&mut self.as_old_mut().name, path, false).map_err(|err| {
+        if is_truncated_gnu_long_path {
+            copy_path_into_gnu_long(&mut self.as_old_mut().name, path, false)
+        } else {
+            copy_path_into(&mut self.as_old_mut().name, path, false)
+        }
+        .map_err(|err| {
             io::Error::new(
                 err.kind(),
                 format!("{} when setting path for {}", err, self.path_lossy()),
@@ -1471,25 +1490,28 @@ fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
     }
 }
 
-/// Copies `path` into the `slot` provided
-///
-/// Returns an error if:
-///
-/// * the path is too long to fit
-/// * a nul byte was found
-/// * an invalid path component is encountered (e.g. a root path or parent dir)
-/// * the path itself is empty
-fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+fn copy_path_into_inner(
+    mut slot: &mut [u8],
+    path: &Path,
+    is_link_name: bool,
+    is_truncated_gnu_long_path: bool,
+) -> io::Result<()> {
     let mut emitted = false;
     let mut needs_slash = false;
-    for component in path.components() {
+    let mut iter = path.components().peekable();
+    while let Some(component) = iter.next() {
         let bytes = path2bytes(Path::new(component.as_os_str()))?;
         match (component, is_link_name) {
             (Component::Prefix(..), false) | (Component::RootDir, false) => {
                 return Err(other("paths in archives must be relative"));
             }
             (Component::ParentDir, false) => {
-                return Err(other("paths in archives must not have `..`"));
+                // If it's last component of a gnu long path we know that there might be more
+                // to the component than .. (the rest is stored elsewhere)
+                // Otherwise it's a clear error
+                if !is_truncated_gnu_long_path || iter.peek().is_some() {
+                    return Err(other("paths in archives must not have `..`"));
+                }
             }
             // Allow "./" as the path
             (Component::CurDir, false) if path.components().count() == 1 => {}
@@ -1520,10 +1542,36 @@ fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::R
 
     fn copy(slot: &mut &mut [u8], bytes: &[u8]) -> io::Result<()> {
         copy_into(slot, bytes)?;
-        let tmp = mem::take(slot);
+        let tmp = std::mem::take(slot);
         *slot = &mut tmp[bytes.len()..];
         Ok(())
     }
+}
+
+/// Copies `path` into the `slot` provided
+///
+/// Returns an error if:
+///
+/// * the path is too long to fit
+/// * a nul byte was found
+/// * an invalid path component is encountered (e.g. a root path or parent dir)
+/// * the path itself is empty
+fn copy_path_into(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+    copy_path_into_inner(slot, path, is_link_name, false)
+}
+
+/// Copies `path` into the `slot` provided
+///
+/// Returns an error if:
+///
+/// * the path is too long to fit
+/// * a nul byte was found
+/// * an invalid path component is encountered (e.g. a root path or parent dir)
+/// * the path itself is empty
+///
+/// This is less restrictive version meant to be used for truncated GNU paths.
+fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+    copy_path_into_inner(slot, path, is_link_name, true)
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -217,6 +217,37 @@ async fn large_filename() {
     assert!(entries.next().await.is_none());
 }
 
+// This test checks very particular scenario where a path component starting
+// with ".." of a long path gets split at 100-byte mark so that ".." part goes
+// into header and gets interpreted as parent dir (and rejected) .
+#[tokio::test]
+async fn large_filename_with_dot_dot_at_100_byte_mark() {
+    let mut ar = Builder::new(Vec::new());
+
+    let mut header = Header::new_gnu();
+    header.set_mode(0o644);
+    header.set_size(4);
+
+    let mut long_name_with_dot_dot = "tdir/".repeat(19);
+    long_name_with_dot_dot.push_str("tt/..file");
+
+    t!(ar
+        .append_data(&mut header, &long_name_with_dot_dot, b"test".as_slice())
+        .await);
+
+    let rd = Cursor::new(t!(ar.into_inner().await));
+    let mut ar = Archive::new(rd);
+    let mut entries = t!(ar.entries());
+
+    let mut f = t!(entries.next().await.unwrap());
+    assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
+    assert_eq!(f.header().size().unwrap(), 4);
+    let mut s = String::new();
+    t!(f.read_to_string(&mut s).await);
+    assert_eq!(s, "test");
+    assert!(entries.next().await.is_none());
+}
+
 #[tokio::test]
 async fn reading_entries() {
     let rdr = Cursor::new(tar!("reading_files.tar"));
@@ -1179,6 +1210,21 @@ async fn long_path() {
     let rdr = Cursor::new(tar!("7z_long_path.tar"));
     let mut ar = Archive::new(rdr);
     ar.unpack(td.path()).await.unwrap();
+}
+
+#[tokio::test]
+async fn append_long_multibyte() {
+    let mut x = Builder::new(Vec::new());
+    let mut name = String::new();
+    let data: &[u8] = &[];
+    for _ in 0..512 {
+        name.push('a');
+        name.push('𑢮');
+        x.append_data(&mut Header::new_gnu(), &name, data)
+            .await
+            .unwrap();
+        name.pop();
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Ports https://github.com/alexcrichton/tar-rs/pull/390 to `async-tar`.

Also includes https://github.com/alexcrichton/tar-rs/pull/241 which preceded it.
