### PR TITLE
Avoid truncation during pending reads

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -9,7 +9,7 @@ use std::{
     collections::VecDeque,
     convert::TryFrom,
     fmt,
-    io::{Cursor, Error, ErrorKind, SeekFrom},
+    io::{Error, ErrorKind, SeekFrom},
     marker,
     path::{Component, Path, PathBuf},
     pin::Pin,
@@ -348,22 +348,12 @@ impl<R: Read + Unpin> EntryFields<R> {
     pub(crate) fn poll_read_all(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        out: &mut Cursor<Vec<u8>>,
+        out: &mut Vec<u8>,
     ) -> Poll<io::Result<()>> {
-        // Preallocate some data but don't let ourselves get too crazy now.
-        let cap = cmp::min(self.size, 128 * 1024);
-        let mut buf = Vec::with_capacity(cap as usize);
-
         // Copied from futures::ReadToEnd
-        match poll_read_all_internal(self, cx, &mut buf) {
-            Poll::Ready(t) => {
-                std::io::Write::write_all(out, &buf)?;
-                Poll::Ready(t.map(|_| ()))
-            }
-            Poll::Pending => {
-                std::io::Write::write_all(out, &buf)?;
-                Poll::Pending
-            }
+        match poll_read_all_internal(self, cx, out) {
+            Poll::Ready(t) => Poll::Ready(t.map(|_| ())),
+            Poll::Pending => Poll::Pending,
         }
     }
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -908,12 +908,13 @@ async fn pax_simple() {
 async fn pax_pending_interrupted() {
     use std::pin::Pin;
 
-    struct SirPendalot<R> {
+    /// A [`tokio::io::AsyncRead`] that returns `Pending` on every other poll.
+    struct PendingReader<R> {
         inner: R,
         n: usize,
     }
 
-    impl<R> SirPendalot<R>
+    impl<R> PendingReader<R>
     where
         R: AsyncRead + Unpin,
     {
@@ -929,15 +930,15 @@ async fn pax_pending_interrupted() {
             (Pin::new(inner), n)
         }
     }
-    impl<R> AsyncRead for SirPendalot<R>
+    impl<R> AsyncRead for PendingReader<R>
     where
         R: AsyncRead + Unpin,
     {
         fn poll_read(
-            self: std::pin::Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
-            buf: &mut tokio::io::ReadBuf<'_>,
-        ) -> std::task::Poll<std::io::Result<()>> {
+            buf: &mut io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
             use std::task::Poll;
 
             let (inner, n) = self.project();
@@ -955,7 +956,7 @@ async fn pax_pending_interrupted() {
     }
 
     let ar = tar!("paxlongname.tar");
-    let ar = SirPendalot::new(ar);
+    let ar = PendingReader::new(ar);
     let mut ar = Archive::new(ar);
     let mut entries = t!(ar.entries());
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -908,7 +908,7 @@ async fn pax_simple() {
 async fn pax_pending_interrupted() {
     use std::pin::Pin;
 
-    /// A [`tokio::io::AsyncRead`] that returns `Pending` on every other poll.
+    /// A [`AsyncRead`] that returns `Pending` on every other poll.
     struct PendingReader<R> {
         inner: R,
         n: usize,


### PR DESCRIPTION
## Summary

Right now, if we hit a pending read while reading an entry, we end up discarding the data rather than preserving it for the next poll (e.g., for a PAX extension). You can also see this reported at https://github.com/dignifiedquire/async-tar/issues/39.

This PR takes https://github.com/dignifiedquire/async-tar/pull/55, but applies an additional change as that PR didn't work on its own, in my testing. Atop https://github.com/dignifiedquire/async-tar/pull/55, we also store the pending `Entry` to ensure that if we're pending, we don't advance to the next entry on the next poll.

For more context, see: https://github.com/astral-sh/tokio-tar/pull/1.

