### PR TITLE
Ship archives in crates.io releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
 edition = "2021"
-exclude = ["tests/archives/*"]
 
 description = """
 A Rust implementation of an async TAR file reader and writer. This library does not


### PR DESCRIPTION
In Debian we package the crates.io release. This means I can't run the tests locally because the testdata is missing