### PR TITLE
Enable opt-in to deny creation of symlinks outside target directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+* Enable opt-in to deny creation of symlinks outside target directory by @charliermarsh in https://github.com/astral-sh/tokio-tar/pull/46
+
 ## 0.5.1
 
 * Add test to reproduce issue in `impl Stream for Entries` causing filename truncation by @charliermarsh in https://github.com/astral-sh/tokio-tar/pull/41

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ the following modifications:
   In [`alexcrichton/tar-rs`](https://github.com/alexcrichton/tar-rs), setting `preserve_permissions`
   to `false` will still set read, write, and execute permissions on extracted files, but will avoid
   setting extended permissions (e.g., `setuid`, `setgid`, and `sticky` bits).
+- Setting `allow_external_symlinks` to `false` will avoid extracting symlinks that point outside the
+  unpack target. Operations that _write_ outside the unpack directory are _always_ denied; but by
+  default, symlinks that _read_ outside the unpack directory are allowed.
 
 See the [changelog](CHANGELOG.md) for a more detailed list of changes.
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,151 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Normalize an absolute path.
+pub(crate) fn normalize_absolute(p: &Path) -> Option<PathBuf> {
+    debug_assert!(p.is_absolute(), "Target must be an absolute path");
+
+    let mut resolved = PathBuf::new();
+    for component in p.components() {
+        match component {
+            Component::Prefix(prefix) => {
+                // Windows-specific: preserve drive letter and prefix.
+                resolved.push(prefix.as_os_str());
+            }
+            Component::RootDir => {
+                // Append root directory after prefix.
+                resolved.push(component.as_os_str());
+            }
+            Component::CurDir => {
+                // Ignore `.`
+            }
+            Component::ParentDir => {
+                if !resolved.pop() {
+                    return None;
+                }
+            }
+            Component::Normal(segment) => {
+                resolved.push(segment);
+            }
+        }
+    }
+    Some(resolved)
+}
+
+/// Normalize a path relative to a destination directory.
+pub(crate) fn normalize_relative(dst: &Path, p: &Path) -> Option<PathBuf> {
+    debug_assert!(!p.is_absolute(), "Target must be a relative path");
+    debug_assert!(dst.is_absolute(), "Destination must be an absolute path");
+
+    let mut resolved = dst.to_path_buf();
+    for component in p.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) => {
+                // E.g., `/usr` on Windows.
+                return None;
+            }
+            Component::CurDir => {
+                // Ignore `.`
+            }
+            Component::ParentDir => {
+                if !resolved.pop() {
+                    return None;
+                }
+            }
+            Component::Normal(segment) => {
+                resolved.push(segment);
+            }
+        }
+    }
+    Some(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    #[cfg(unix)]
+    fn test_normalize_absolute() {
+        // Basic absolute path.
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new("/a/b/c")),
+            Some(PathBuf::from("/a/b/c"))
+        );
+
+        // Path with `..` (should remove `b`).
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new("/a/b/../c")),
+            Some(PathBuf::from("/a/c"))
+        );
+
+        // Path with `.`, should be ignored.
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new("/a/./b")),
+            Some(PathBuf::from("/a/b"))
+        );
+
+        // Excessive `..` that escapes root.
+        assert_eq!(crate::fs::normalize_absolute(Path::new("/../b")), None);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_normalize_absolute() {
+        // Basic absolute path.
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new(r"C:\a\b\c")),
+            Some(PathBuf::from(r"C:\a\b\c"))
+        );
+
+        // Path with `..` (should remove `b`).
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new(r"C:\a\b\..\c")),
+            Some(PathBuf::from(r"C:\a\c"))
+        );
+
+        // Path with `.`, should be ignored.
+        assert_eq!(
+            crate::fs::normalize_absolute(Path::new(r"C:\a\.\b")),
+            Some(PathBuf::from(r"C:\a\b"))
+        );
+
+        // Excessive `..` that escapes root.
+        assert_eq!(crate::fs::normalize_absolute(Path::new(r"C:\..\b")), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_normalize_relative() {
+        let dst = Path::new("/home/user/dst");
+
+        // Basic relative path.
+        assert_eq!(
+            crate::fs::normalize_relative(dst, Path::new("a/b/c")),
+            Some(PathBuf::from("/home/user/dst/a/b/c"))
+        );
+
+        // Path with `..`, should remove `b`.
+        assert_eq!(
+            crate::fs::normalize_relative(dst, Path::new("a/b/../c")),
+            Some(PathBuf::from("/home/user/dst/a/c"))
+        );
+
+        // Path with `.` should be ignored.
+        assert_eq!(
+            crate::fs::normalize_relative(dst, Path::new("./a/b")),
+            Some(PathBuf::from("/home/user/dst/a/b"))
+        );
+
+        // Path escaping `dst`, should return None.
+        assert_eq!(
+            crate::fs::normalize_relative(dst, Path::new("../../../../outside")),
+            None
+        );
+
+        // Excessive `..`, escaping `dst`.
+        assert_eq!(
+            crate::fs::normalize_relative(dst, Path::new("../../../../")),
+            None
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod builder;
 mod entry;
 mod entry_type;
 mod error;
+mod fs;
 mod header;
 mod pax;
 

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -6,6 +6,7 @@ extern crate tempfile;
 use tokio::{fs, fs::File, io::AsyncReadExt};
 use tokio_stream::*;
 
+use async_tar::ArchiveBuilder;
 use tempfile::Builder;
 
 macro_rules! t {
@@ -387,4 +388,77 @@ async fn modify_symlink_just_created() {
     let mut contents = Vec::new();
     t!(t!(File::open(&test).await).read_to_end(&mut contents).await);
     assert_eq!(contents.len(), 0);
+}
+
+#[tokio::test]
+async fn deny_absolute_symlink() {
+    let mut ar = async_tar::Builder::new(Vec::new());
+
+    let mut header = async_tar::Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_path("foo"));
+    t!(header.set_link_name("/bar"));
+    header.set_cksum();
+    t!(ar.append(&header, &[][..]).await);
+
+    let bytes = t!(ar.into_inner().await);
+
+    let builder = ArchiveBuilder::new(&bytes[..]).set_allow_external_symlinks(false);
+    let mut ar = builder.build();
+
+    let td = t!(Builder::new().prefix("tar").tempdir());
+    assert!(ar.unpack(td.path()).await.is_err());
+}
+
+#[tokio::test]
+async fn deny_relative_link() {
+    let mut ar = async_tar::Builder::new(Vec::new());
+
+    let mut header = async_tar::Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_path("foo"));
+    t!(header.set_link_name("../../../../"));
+    header.set_cksum();
+    t!(ar.append(&header, &[][..]).await);
+
+    let bytes = t!(ar.into_inner().await);
+
+    let builder = ArchiveBuilder::new(&bytes[..]).set_allow_external_symlinks(false);
+    let mut ar = builder.build();
+
+    let td = t!(Builder::new().prefix("tar").tempdir());
+    assert!(ar.unpack(td.path()).await.is_err());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn accept_relative_link() {
+    let mut ar = async_tar::Builder::new(Vec::new());
+
+    let mut header = async_tar::Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_path("foo/bar"));
+    t!(header.set_link_name("../baz"));
+    header.set_cksum();
+    t!(ar.append(&header, &[][..]).await);
+
+    let mut header = async_tar::Header::new_gnu();
+    header.set_size(1);
+    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_path("baz"));
+    header.set_cksum();
+    t!(ar.append(&header, &b"x"[..]).await);
+
+    let bytes = t!(ar.into_inner().await);
+
+    let builder = ArchiveBuilder::new(&bytes[..]).set_allow_external_symlinks(false);
+    let mut ar = builder.build();
+
+    let td = t!(Builder::new().prefix("tar").tempdir());
+    t!(ar.unpack(td.path()).await);
+    t!(td.path().join("foo/bar").symlink_metadata());
+    t!(File::open(td.path().join("foo").join("bar")).await);
 }


### PR DESCRIPTION
## Summary

To support PEP 721, we need to reject distributions with symlinks that point outside of the target directory. (By default, `tar-rs` allows these, instead rejecting file system operations that would _write_ outside the target directory.)

See: https://github.com/astral-sh/uv/issues/12163
