### PR TITLE
Use safe transmute and remove all unsafe code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo hack check --all --ignore-private --each-feature --no-dev-deps
       - run: cargo check --all --all-targets --all-features
       - run: cargo test
+      # Test without zerocopy
+      - run: cargo test --no-default-features
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   msrv:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+ "zerocopy",
 ]
 
 [[package]]
@@ -211,18 +212,18 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -358,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wasi"
@@ -467,4 +468,24 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ portable-atomic = "1"
 rustc-hash = "2.1.0"
 tokio = { version = "1", features = ["fs", "io-util", "rt"] }
 tokio-stream = "0.1"
+zerocopy = { version = "0.8.52", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -10,6 +10,7 @@ use std::{
     convert::TryFrom,
     fmt,
     fs::FileTimes,
+    future::Future,
     io::{Error, ErrorKind, SeekFrom},
     marker,
     path::{Component, Path, PathBuf},
@@ -1220,54 +1221,18 @@ impl<R: Read + Unpin> Read for EntryIo<R> {
     }
 }
 
-struct Guard<'a> {
-    buf: &'a mut Vec<u8>,
-    len: usize,
-}
-
-impl Drop for Guard<'_> {
-    fn drop(&mut self) {
-        unsafe {
-            self.buf.set_len(self.len);
-        }
-    }
-}
-
-fn poll_read_all_internal<R: Read + ?Sized>(
+fn poll_read_all_internal<R: Read + Unpin + ?Sized>(
     mut rd: Pin<&mut R>,
     cx: &mut Context<'_>,
     buf: &mut Vec<u8>,
 ) -> Poll<io::Result<usize>> {
-    let mut g = Guard {
-        len: buf.len(),
-        buf,
-    };
-    let ret;
     loop {
-        if g.len == g.buf.len() {
-            unsafe {
-                g.buf.reserve(32);
-                let capacity = g.buf.capacity();
-                g.buf.set_len(capacity);
-
-                let buf = &mut g.buf[g.len..];
-                std::ptr::write_bytes(buf.as_mut_ptr(), 0, buf.len());
-            }
-        }
-
-        let mut read_buf = io::ReadBuf::new(&mut g.buf[g.len..]);
-        match futures_core::ready!(rd.as_mut().poll_read(cx, &mut read_buf)) {
-            Ok(()) if read_buf.filled().is_empty() => {
-                ret = Poll::Ready(Ok(g.len));
-                break;
-            }
-            Ok(()) => g.len += read_buf.filled().len(),
-            Err(e) => {
-                ret = Poll::Ready(Err(e));
-                break;
-            }
+        let future = rd.as_mut().get_mut().read_buf(buf);
+        let mut future = std::pin::pin!(future);
+        match futures_core::ready!(future.as_mut().poll(cx)) {
+            Ok(0) => return Poll::Ready(Ok(buf.len())),
+            Ok(_) => {}
+            Err(err) => return Poll::Ready(Err(err)),
         }
     }
-
-    ret
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 #[cfg(unix)]
 use std::os::unix::prelude::*;
 #[cfg(windows)]
@@ -9,11 +11,11 @@ use std::{
     fs::Metadata,
     iter,
     iter::{once, repeat},
-    mem,
     path::{Component, Path, PathBuf},
     str,
 };
 use tokio::io;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{other, EntryType};
 
@@ -28,6 +30,7 @@ const DETERMINISTIC_TIMESTAMP: u64 = 1153704088;
 pub(crate) const BLOCK_SIZE: u64 = 512;
 
 /// Representation of the header of an entry in an archive
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct Header {
@@ -49,6 +52,7 @@ pub enum HeaderMode {
 }
 
 /// Representation of the header of an entry in an archive
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct OldHeader {
@@ -65,6 +69,7 @@ pub struct OldHeader {
 }
 
 /// Representation of the header of an entry in an archive
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct UstarHeader {
@@ -90,6 +95,7 @@ pub struct UstarHeader {
 }
 
 /// Representation of the header of an entry in an archive
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct GnuHeader {
@@ -124,6 +130,7 @@ pub struct GnuHeader {
 /// Description of the header of a spare entry.
 ///
 /// Specifies the offset/number of bytes of a chunk of data in octal.
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct GnuSparseHeader {
@@ -135,6 +142,7 @@ pub struct GnuSparseHeader {
 ///
 /// When a `GnuHeader` has the `isextended` flag set to `1` then the contents of
 /// the next entry will be one of these headers.
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct GnuExtSparseHeader {
@@ -153,11 +161,9 @@ impl Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
-        unsafe {
-            let gnu = cast_mut::<_, GnuHeader>(&mut header);
-            gnu.magic = *b"ustar ";
-            gnu.version = *b" \0";
-        }
+        let gnu: &mut GnuHeader = zerocopy::transmute_mut!(&mut header);
+        gnu.magic = *b"ustar ";
+        gnu.version = *b" \0";
         header.set_mtime(0);
         header
     }
@@ -173,11 +179,9 @@ impl Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
-        unsafe {
-            let gnu = cast_mut::<_, UstarHeader>(&mut header);
-            gnu.magic = *b"ustar\0";
-            gnu.version = *b"00";
-        }
+        let gnu: &mut UstarHeader = zerocopy::transmute_mut!(&mut header);
+        gnu.magic = *b"ustar\0";
+        gnu.version = *b"00";
         header.set_mtime(0);
         header
     }
@@ -197,17 +201,17 @@ impl Header {
     }
 
     fn is_ustar(&self) -> bool {
-        let ustar = unsafe { cast::<_, UstarHeader>(self) };
+        let ustar: &UstarHeader = zerocopy::transmute_ref!(self);
         ustar.magic[..] == b"ustar\0"[..] && ustar.version[..] == b"00"[..]
     }
 
     pub(crate) fn is_ambiguous_nul_version_ustar(&self) -> bool {
-        let ustar = unsafe { cast::<_, UstarHeader>(self) };
+        let ustar: &UstarHeader = zerocopy::transmute_ref!(self);
         ustar.magic[..] == b"ustar\0"[..] && ustar.version[..] == b"\0\0"[..]
     }
 
     fn is_gnu(&self) -> bool {
-        let ustar = unsafe { cast::<_, UstarHeader>(self) };
+        let ustar: &UstarHeader = zerocopy::transmute_ref!(self);
         ustar.magic[..] == b"ustar "[..] && ustar.version[..] == b" \0"[..]
     }
 
@@ -216,12 +220,12 @@ impl Header {
     /// This view will always succeed as all archive header formats will fill
     /// out at least the fields specified in the old header format.
     pub fn as_old(&self) -> &OldHeader {
-        unsafe { cast(self) }
+        zerocopy::transmute_ref!(self)
     }
 
     /// Same as `as_old`, but the mutable version.
     pub fn as_old_mut(&mut self) -> &mut OldHeader {
-        unsafe { cast_mut(self) }
+        zerocopy::transmute_mut!(self)
     }
 
     /// View this archive header as a raw UStar archive header.
@@ -235,7 +239,7 @@ impl Header {
     /// returning `None` if they aren't correct.
     pub fn as_ustar(&self) -> Option<&UstarHeader> {
         if self.is_ustar() {
-            Some(unsafe { cast(self) })
+            Some(zerocopy::transmute_ref!(self))
         } else {
             None
         }
@@ -244,7 +248,7 @@ impl Header {
     /// Same as `as_ustar_mut`, but the mutable version.
     pub fn as_ustar_mut(&mut self) -> Option<&mut UstarHeader> {
         if self.is_ustar() {
-            Some(unsafe { cast_mut(self) })
+            Some(zerocopy::transmute_mut!(self))
         } else {
             None
         }
@@ -261,7 +265,7 @@ impl Header {
     /// returning `None` if they aren't correct.
     pub fn as_gnu(&self) -> Option<&GnuHeader> {
         if self.is_gnu() {
-            Some(unsafe { cast(self) })
+            Some(zerocopy::transmute_ref!(self))
         } else {
             None
         }
@@ -270,7 +274,7 @@ impl Header {
     /// Same as `as_gnu`, but the mutable version.
     pub fn as_gnu_mut(&mut self) -> Option<&mut GnuHeader> {
         if self.is_gnu() {
-            Some(unsafe { cast_mut(self) })
+            Some(zerocopy::transmute_mut!(self))
         } else {
             None
         }
@@ -280,9 +284,7 @@ impl Header {
     ///
     /// Panics if the length of the passed slice is not equal to 512.
     pub fn from_byte_slice(bytes: &[u8]) -> &Header {
-        assert_eq!(bytes.len(), mem::size_of::<Header>());
-        assert_eq!(mem::align_of_val(bytes), mem::align_of::<Header>());
-        unsafe { &*(bytes.as_ptr() as *const Header) }
+        Self::ref_from_bytes(bytes).unwrap()
     }
 
     /// Returns a view into this header as a byte array.
@@ -920,18 +922,6 @@ impl<T: fmt::Octal> fmt::Debug for DebugAsOctal<T> {
     }
 }
 
-unsafe fn cast<T, U>(a: &T) -> &U {
-    assert_eq!(mem::size_of_val(a), mem::size_of::<U>());
-    assert_eq!(mem::align_of_val(a), mem::align_of::<U>());
-    &*(a as *const T as *const U)
-}
-
-unsafe fn cast_mut<T, U>(a: &mut T) -> &mut U {
-    assert_eq!(mem::size_of_val(a), mem::size_of::<U>());
-    assert_eq!(mem::align_of_val(a), mem::align_of::<U>());
-    &mut *(a as *mut T as *mut U)
-}
-
 impl Clone for Header {
     fn clone(&self) -> Header {
         Header { bytes: self.bytes }
@@ -953,12 +943,12 @@ impl fmt::Debug for Header {
 impl OldHeader {
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
-        unsafe { cast(self) }
+        zerocopy::transmute_ref!(self)
     }
 
     /// Views this as a normal `Header`
     pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
+        zerocopy::transmute_mut!(self)
     }
 }
 
@@ -1124,12 +1114,12 @@ impl UstarHeader {
 
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
-        unsafe { cast(self) }
+        zerocopy::transmute_ref!(self)
     }
 
     /// Views this as a normal `Header`
     pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
+        zerocopy::transmute_mut!(self)
     }
 }
 
@@ -1295,12 +1285,12 @@ impl GnuHeader {
 
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
-        unsafe { cast(self) }
+        zerocopy::transmute_ref!(self)
     }
 
     /// Views this as a normal `Header`
     pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
+        zerocopy::transmute_mut!(self)
     }
 }
 
@@ -1381,19 +1371,17 @@ impl fmt::Debug for GnuSparseHeader {
 impl GnuExtSparseHeader {
     /// Crates a new zero'd out sparse header entry.
     pub fn new() -> GnuExtSparseHeader {
-        unsafe { mem::zeroed() }
+        zerocopy::transmute!([0u8; size_of::<GnuExtSparseHeader>()])
     }
 
     /// Returns a view into this header as a byte array.
     pub fn as_bytes(&self) -> &[u8; BLOCK_SIZE as usize] {
-        debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
-        unsafe { &*(self as *const GnuExtSparseHeader as *const [u8; BLOCK_SIZE as usize]) }
+        zerocopy::transmute_ref!(self)
     }
 
     /// Returns a view into this header as a byte array.
     pub fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
-        debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
-        unsafe { &mut *(self as *mut GnuExtSparseHeader as *mut [u8; BLOCK_SIZE as usize]) }
+        zerocopy::transmute_mut!(self)
     }
 
     /// Returns a slice of the underlying sparse headers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![deny(missing_docs)]
 #![deny(clippy::print_stderr, clippy::print_stdout)]
+#![deny(unsafe_code)]
 
 use std::io::Error;
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -2248,19 +2248,15 @@ async fn read_only_directory_containing_files() {
 #[cfg(target_os = "linux")]
 async fn tar_directory_containing_special_files() {
     use std::env;
-    use std::ffi::CString;
 
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
     let fifo = td.path().join("fifo");
 
-    unsafe {
-        let fifo_path = t!(CString::new(fifo.to_str().unwrap()));
-        let ret = libc::mknod(fifo_path.as_ptr(), libc::S_IFIFO | 0o644, 0);
-        if ret != 0 {
-            libc::perror(fifo_path.as_ptr());
-            panic!("Failed to create a FIFO file");
-        }
-    }
+    t!(rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        fifo.as_path(),
+        rustix::fs::Mode::from_raw_mode(0o644),
+    ));
 
     t!(env::set_current_dir(td.path()));
     let mut ar = Builder::new(Vec::new());

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -3,7 +3,6 @@
 use std::{
     fs::{self, File},
     io::Write,
-    mem,
     path::Path,
     thread, time,
 };
@@ -228,7 +227,8 @@ fn set_metadata_deterministic() {
 
 #[test]
 fn extended_numeric_format() {
-    let mut h: GnuHeader = unsafe { mem::zeroed() };
+    let mut header = Header::new_gnu();
+    let h: &mut GnuHeader = header.as_gnu_mut().unwrap();
     h.as_header_mut().set_size(42);
     assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]);
     h.as_header_mut().set_size(8589934593);


### PR DESCRIPTION
Using the zerocopy crate, we can port all header conversions from pointer cast to safe transmutes. After this change, the code in `header.rs` does not use `unsafe`. We're trading one extra dependency for no more unsafes.