### PR TITLE
Minimum Rust version: N-2 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   msrv:
-    name: "Test (msrv)"
+    name: msrv
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,18 @@ jobs:
       - run: cargo check --all --all-targets --all-features
       - run: cargo test
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  msrv:
+    name: "Test (msrv)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: SebRollen/toml-action@v1.2.0
+        id: msrv
+        with:
+          file: "Cargo.toml"
+          field: "package.rust-version"
+      - name: "Install Rust toolchain"
+        run: rustup default ${{ steps.msrv.outputs.value }}
+      - run: cargo +${{ steps.msrv.outputs.value }} test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 0.5.2
-
-* Update to Rust edition 2024
-
 ## 0.5.1
 
 * Add test to reproduce issue in `impl Stream for Entries` causing filename truncation by @charliermarsh in https://github.com/astral-sh/tokio-tar/pull/41

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
 edition = "2021"
+rust-version = "1.83.0"
 
 description = """
 A Rust implementation of an async TAR file reader and writer. This library does not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/tokio-tar"
 license = "MIT OR Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
-edition = "2024"
+edition = "2021"
 
 description = """
 A Rust implementation of an async TAR file reader and writer. This library does not

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -17,10 +17,9 @@ use tokio_stream::*;
 
 use crate::header::BLOCK_SIZE;
 use crate::{
-    Entry, GnuExtSparseHeader, GnuSparseHeader, Header,
     entry::{EntryFields, EntryIo},
     error::TarError,
-    other,
+    other, Entry, GnuExtSparseHeader, GnuSparseHeader, Header,
 };
 
 /// A top-level representation of an archive file.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,6 @@
 use crate::{
-    EntryType, Header,
-    header::{HeaderMode, path2bytes},
-    other,
+    header::{path2bytes, HeaderMode},
+    other, EntryType, Header,
 };
 use std::{fs::Metadata, path::Path, str};
 use tokio::{

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Archive, Header, PaxExtensions, error::TarError, header::bytes2path, other, pax::pax_extensions,
+    error::TarError, header::bytes2path, other, pax::pax_extensions, Archive, Header, PaxExtensions,
 };
 use filetime::{self, FileTime};
 use rustc_hash::FxHashSet;
@@ -17,7 +17,7 @@ use std::{
 };
 use tokio::{
     fs,
-    fs::{OpenOptions, remove_file},
+    fs::{remove_file, OpenOptions},
     io::{self, AsyncRead as Read, AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
 
@@ -926,7 +926,7 @@ impl<R: Read + Unpin> Read for EntryFields<R> {
                 this.read_state = this.data.pop_front();
             }
 
-            if let Some(io) = &mut this.read_state {
+            if let Some(ref mut io) = &mut this.read_state {
                 let start = into.filled().len();
                 let ret = Pin::new(io).poll_read(cx, into);
                 match ret {
@@ -962,8 +962,8 @@ impl<R: Read + Unpin> Read for EntryIo<R> {
         into: &mut io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
-            EntryIo::Pad(io) => Pin::new(io).poll_read(cx, into),
-            EntryIo::Data(io) => Pin::new(io).poll_read(cx, into),
+            EntryIo::Pad(ref mut io) => Pin::new(io).poll_read(cx, into),
+            EntryIo::Data(ref mut io) => Pin::new(io).poll_read(cx, into),
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use tokio::io;
 
-use crate::{EntryType, other};
+use crate::{other, EntryType};
 
 /// A deterministic, arbitrary, non-zero timestamp that use used as `mtime`
 /// of headers when [`HeaderMode::Deterministic`] is used.
@@ -913,13 +913,13 @@ impl<T: fmt::Octal> fmt::Debug for DebugAsOctal<T> {
 unsafe fn cast<T, U>(a: &T) -> &U {
     assert_eq!(mem::size_of_val(a), mem::size_of::<U>());
     assert_eq!(mem::align_of_val(a), mem::align_of::<U>());
-    unsafe { &*(a as *const T as *const U) }
+    &*(a as *const T as *const U)
 }
 
 unsafe fn cast_mut<T, U>(a: &mut T) -> &mut U {
     assert_eq!(mem::size_of_val(a), mem::size_of::<U>());
     assert_eq!(mem::align_of_val(a), mem::align_of::<U>());
-    unsafe { &mut *(a as *mut T as *mut U) }
+    &mut *(a as *mut T as *mut U)
 }
 
 impl Clone for Header {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -278,24 +278,18 @@ async fn check_dirtree(td: &TempDir) {
     let dir_a = td.path().join("a");
     let dir_b = td.path().join("a/b");
     let file_c = td.path().join("a/c");
-    assert!(
-        fs::metadata(&dir_a)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(&dir_b)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(&file_c)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&dir_a)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
+    assert!(fs::metadata(&dir_b)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
+    assert!(fs::metadata(&file_c)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
 }
 
 #[tokio::test]
@@ -461,33 +455,25 @@ async fn writing_directories_recursively() {
     let mut ar = Archive::new(Cursor::new(data));
     t!(ar.unpack(td.path()).await);
     let base_dir = td.path().join("foobar");
-    assert!(
-        fs::metadata(&base_dir)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&base_dir)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
     let file1_path = base_dir.join("file1");
-    assert!(
-        fs::metadata(&file1_path)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&file1_path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
     let sub_dir = base_dir.join("sub");
-    assert!(
-        fs::metadata(&sub_dir)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&sub_dir)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
     let file2_path = sub_dir.join("file2");
-    assert!(
-        fs::metadata(&file2_path)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&file2_path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
 }
 
 #[tokio::test]
@@ -512,33 +498,25 @@ async fn append_dir_all_blank_dest() {
     let mut ar = Archive::new(Cursor::new(data));
     t!(ar.unpack(td.path()).await);
     let base_dir = td.path();
-    assert!(
-        fs::metadata(&base_dir)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&base_dir)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
     let file1_path = base_dir.join("file1");
-    assert!(
-        fs::metadata(&file1_path)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&file1_path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
     let sub_dir = base_dir.join("sub");
-    assert!(
-        fs::metadata(&sub_dir)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&sub_dir)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
     let file2_path = sub_dir.join("file2");
-    assert!(
-        fs::metadata(&file2_path)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&file2_path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
 }
 
 #[tokio::test]
@@ -562,12 +540,10 @@ async fn extracting_duplicate_dirs() {
     t!(ar.unpack(td.path()).await);
 
     let some_dir = td.path().join("some_dir");
-    assert!(
-        fs::metadata(&some_dir)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&some_dir)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
 }
 
 #[tokio::test]
@@ -701,26 +677,18 @@ async fn extracting_malicious_tarball() {
     assert!(fs::metadata("/tmp/abs_evil.txt6").await.is_err());
     assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
     assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
-    assert!(
-        fs::metadata(td.path().join("../tmp/rel_evil.txt"))
-            .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil2.txt"))
-            .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil3.txt"))
-            .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil4.txt"))
-            .await
-            .is_err()
-    );
+    assert!(fs::metadata(td.path().join("../tmp/rel_evil.txt"))
+        .await
+        .is_err());
+    assert!(fs::metadata(td.path().join("../rel_evil2.txt"))
+        .await
+        .is_err());
+    assert!(fs::metadata(td.path().join("../rel_evil3.txt"))
+        .await
+        .is_err());
+    assert!(fs::metadata(td.path().join("../rel_evil4.txt"))
+        .await
+        .is_err());
 
     // The `some` subdirectory should not be created because the only
     // filename that references this has '..'.
@@ -729,64 +697,46 @@ async fn extracting_malicious_tarball() {
     // The `tmp` subdirectory should be created and within this
     // subdirectory, there should be files named `abs_evil.txt` through
     // `abs_evil6.txt`.
-    assert!(
-        fs::metadata(td.path().join("tmp"))
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil2.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil3.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil4.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil5.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(td.path().join("tmp/abs_evil6.txt"))
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(td.path().join("tmp"))
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil2.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil3.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil4.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil5.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
+    assert!(fs::metadata(td.path().join("tmp/abs_evil6.txt"))
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
 
     // Paths "//tmp/abs_evil2.txt" and "//./tmp/abs_evil5.txt" are not absolute for Windows,
     // hence this test part does not work as expected on this OS.
     if cfg!(not(windows)) {
-        assert!(
-            fs::metadata(td.path().join("tmp/abs_evil2.txt"))
-                .await
-                .map(|m| m.is_file())
-                .unwrap_or(false)
-        );
-        assert!(
-            fs::metadata(td.path().join("tmp/abs_evil5.txt"))
-                .await
-                .map(|m| m.is_file())
-                .unwrap_or(false)
-        );
+        assert!(fs::metadata(td.path().join("tmp/abs_evil2.txt"))
+            .await
+            .map(|m| m.is_file())
+            .unwrap_or(false));
+        assert!(fs::metadata(td.path().join("tmp/abs_evil5.txt"))
+            .await
+            .map(|m| m.is_file())
+            .unwrap_or(false));
     }
 }
 
@@ -1014,10 +964,7 @@ async fn pax_pending_interrupted() {
     let path = t!(entry.path());
     let path = path.to_str().unwrap();
 
-    assert_eq!(
-        path,
-        "this_file_name_will_be_one_hundred_and_one_characters_long_once_i_add_some_more_characters_at_the_end"
-    );
+    assert_eq!(path, "this_file_name_will_be_one_hundred_and_one_characters_long_once_i_add_some_more_characters_at_the_end");
 }
 
 #[tokio::test]


### PR DESCRIPTION
To keep being able to use the latest version of this crate in uv, we set the minimum supported Rust version - for now - to N-2, which is currently 1.83. In the process, we revert the Rust edition 2024 update.