### PR TITLE
Preserve leading "./" in paths for Debian package compatibility

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1514,8 +1514,11 @@ fn copy_path_into_inner(
 ) -> io::Result<()> {
     let mut emitted = false;
     let mut needs_slash = false;
-    let mut iter = path.components().peekable();
-    while let Some(component) = iter.next() {
+
+    let component_count = path.components().count();
+    let components = path.components().enumerate();
+
+    for (position, component) in components {
         let bytes = path2bytes(Path::new(component.as_os_str()))?;
         match (component, is_link_name) {
             (Component::Prefix(..), false) | (Component::RootDir, false) => {
@@ -1525,12 +1528,13 @@ fn copy_path_into_inner(
                 // If it's last component of a gnu long path we know that there might be more
                 // to the component than .. (the rest is stored elsewhere)
                 // Otherwise it's a clear error
-                if !is_truncated_gnu_long_path || iter.peek().is_some() {
+                let is_last_component = position == component_count - 1;
+                if !is_truncated_gnu_long_path || !is_last_component {
                     return Err(other("paths in archives must not have `..`"));
                 }
             }
-            // Allow "./" as the path
-            (Component::CurDir, false) if path.components().count() == 1 => {}
+            // Allow paths starting with "./" as the path
+            (Component::CurDir, false) if position == 0 => {}
             (Component::CurDir, false) => continue,
             (Component::Normal(_), _) | (_, true) => {}
         };

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -144,11 +144,19 @@ fn set_path() {
         assert_eq!(t!(h.path()).to_str(), Some("foo\\bar"));
     }
 
-    // set_path documentation explictly states it removes any ".", signfying the
-    // current directory, from the path. This test ensures that documented
-    // beavhior occurs
+    // set_path documentation explicitly states it removes any "." from the path,
+    // except when at the beginning. That is:
+    // - "./control" is allowed (leading dot-slash is preserved)
+    // - "foo/./control" is not allowed (middle dot-slash is rejected)
+    // This test ensures that documented behavior occurs
     t!(h.set_path("./control"));
-    assert_eq!(t!(h.path()).to_str(), Some("control"));
+    assert_eq!(t!(h.path()).to_str(), Some("./control"));
+
+    t!(h.set_path("./foo/./control"));
+    assert_eq!(t!(h.path()).to_str(), Some("./foo/control"));
+
+    t!(h.set_path("./bar/./control/./"));
+    assert_eq!(t!(h.path()).to_str(), Some("./bar/control/"));
 
     let long_name = "foo".repeat(100);
     let medium1 = "foo".repeat(52);


### PR DESCRIPTION
Hi @charliermarsh, congrats on the project!

This PR suggests fixing `Header::set_path`'s 'incorrect' behavior of stripping away the leading dot-slash in paths.
The reasoning for this is that Debian/Ubuntu packaging (`.deb`s) require their data tarballs to state their entries as follows:

```
drwxr-xr-x root/root         0 2023-07-29 15:58 ./
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/15/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/15/lib/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/15/lib/bitcode/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/15/lib/bitcode/vector/
drwxr-xr-x root/root         0 2023-07-29 15:58 ./usr/lib/postgresql/15/lib/bitcode/vector/src/
-rw-r--r-- root/root     20460 2023-07-29 15:58 ./usr/lib/postgresql/15/lib/bitcode/vector/src/ivfbuild.bc
``` 

The current `tar-rs` processing instead converts those into:

```
drwxr-xr-x root/root         0 2023-07-29 15:58 ./
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/15/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/15/lib/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/15/lib/bitcode/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/15/lib/bitcode/vector/
drwxr-xr-x root/root         0 2023-07-29 15:58 usr/lib/postgresql/15/lib/bitcode/vector/src/
-rw-r--r-- root/root     20460 2023-07-29 15:58 usr/lib/postgresql/15/lib/bitcode/vector/src/ivfbuild.bc
```

The lack of leading dot-slash in the files above makes Debian tooling (`apt`/`dpkg`) to extract files in the incorrect folders, or reject the .deb entirely (now I can't recall for sure)

This has been a known `tar-rs` issue for years, described in issues such as https://github.com/alexcrichton/tar-rs/issues/263 and https://github.com/alexcrichton/tar-rs/issues/335, but we haven't had much luck in hearing back from Alex, so I suppose it's better to try to fix this here, downstream
