### PR TITLE
Bump to v0.5.3 (Update changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+* Expose `TarError` publicly by @konstin in https://github.com/astral-sh/tokio-tar/pull/52
+
 ## 0.5.2
 
 * Enable opt-in to deny creation of symlinks outside target directory by @charliermarsh in https://github.com/astral-sh/tokio-tar/pull/46


### PR DESCRIPTION
Release v0.5.3 for https://github.com/astral-sh/uv/pull/15202#issuecomment-3200209608. The `Cargo.toml` is already bumped, so we only need update the Changelog.