### PR TITLE
Use Trusted Publishing with crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,23 @@ permissions: {}
 
 jobs:
   publish:
+    name: Publish to crates.io
     runs-on: ubuntu-latest
     environment:
       name: crates-io
+
+    permissions:
+      id-token: write # for Trusted Publishing to crates.io
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
+
       - name: Publish to crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: "${{ steps.auth.outputs.token }}"


### PR DESCRIPTION
This switches the publish workflow to Trusted Publishing. One of the owners on crates.io (maybe @konstin?) will need to configure the publisher on that side (with `crates-io` as the optional environment, since we're using that).

- [x] Enroll the publisher on crates.io (an owner needs to do this)
- [x] Delete the old API key in GHA secrets
- [x] Delete the old API key on crates.io