### PR TITLE
Only write pax archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Restricted archive writing to validated high-level PAX/USTAR builder APIs.
+  Archive names and symbolic-link targets are now validated UTF-8 values, and
+  valid non-ASCII values are emitted using PAX `path`/`linkpath` records.
+* Removed raw writable `Header`/`Builder::append` entry construction in favor
+  of generated-entry methods and `EntryMetadata`.
+
 ## 0.5.6
 
 * Fixed a parser desynchronization vulnerability when reading tar archives that

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -18,7 +18,8 @@ use tokio_stream::*;
 use crate::{
     entry::{EntryFields, EntryIo},
     error::TarError,
-    other, Entry, GnuExtSparseHeader, GnuSparseHeader, Header,
+    header::GnuExtSparseHeader,
+    other, Entry, GnuSparseHeader, Header,
 };
 use crate::{header::BLOCK_SIZE, pax::pax_extensions};
 
@@ -648,6 +649,14 @@ fn poll_next_raw<R: Read + Unpin>(
                             .parse::<u64>()
                             .map_err(|_e| other("failed to parse pax gid"))?,
                     );
+                }
+
+                "mtime" => {
+                    if let Ok(mtime_str) = extension.value() {
+                        if let Ok(mtime) = mtime_str.parse::<u64>() {
+                            header.set_mtime(mtime);
+                        }
+                    }
                 }
 
                 _ => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,9 @@
 use crate::{
     header::HeaderMode,
-    name::{into_link_target, into_name},
-    other, EntryType, Header, LinkTarget, Name,
+    name::{archive_name as checked, link_target},
+    other, EntryType, Header,
 };
-use std::{fmt, fs::Metadata, path::Path};
+use std::{fs::Metadata, path::Path};
 use tokio::{
     fs,
     io::{self, AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt},
@@ -158,7 +158,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
 
     /// Adds a generated regular-file entry to this archive.
     ///
-    /// A PAX `path` extension is emitted when the validated [`Name`] is too
+    /// A PAX `path` extension is emitted when the validated name is too
     /// long for USTAR or contains non-ASCII UTF-8. `size` must equal the
     /// number of bytes read from `data`.
     ///
@@ -189,10 +189,13 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_data<N, R>(&mut self, path: N, size: u64, data: R) -> io::Result<()>
+    pub async fn append_data<N: AsRef<Path>, R>(
+        &mut self,
+        path: N,
+        size: u64,
+        data: R,
+    ) -> io::Result<()>
     where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
         R: Read + Unpin,
     {
         self.append_data_with_metadata(path, size, EntryMetadata::new(), data)
@@ -208,73 +211,35 @@ impl<W: Write + Unpin + Send> Builder<W> {
         data: R,
     ) -> io::Result<()>
     where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
+        N: AsRef<Path>,
         R: Read + Unpin,
     {
-        let path = into_name(path)?;
-        let mut header = Header::new_ustar();
-        metadata.apply(&mut header, DEFAULT_FILE_MODE);
-        header.set_size(size);
-        let mut pax_extensions = Vec::new();
-        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
-        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-        validate_header_for_write(&header)?;
-        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
-        header.set_cksum();
-        append_entry(self.get_mut(), &header, data).await
+        let entry = generated_entry(
+            &checked(path.as_ref())?,
+            size,
+            EntryType::Regular,
+            metadata,
+            DEFAULT_FILE_MODE,
+        )?;
+        append_generated(self.get_mut(), entry, data).await
     }
 
-    /// Adds a new hard-link entry to this archive with the specified name and destination.
-    ///
-    /// This function sets the specified member name and hard-link destination
-    /// in the header, appending a
-    /// PAX extension entry first when either value is too long for USTAR or
-    /// contains non-ASCII characters. The checksum for the header is updated
-    /// automatically.
-    ///
-    /// The entry type is set to [`EntryType::Link`] and the size is set to zero.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error for any intermittent I/O error which
-    /// occurs when writing, or if the header cannot describe a USTAR/PAX link
-    /// entry.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { tokio::runtime::Runtime::new().unwrap().block_on(async {
-    /// #
-    /// use tokio_tar::Builder;
-    ///
-    /// let mut ar = Builder::new(Vec::new());
-    /// ar.append_hard_link("link", "really/long/link/target").await?;
-    /// let data = ar.into_inner().await?;
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn append_hard_link<N, T>(&mut self, path: N, target: T) -> io::Result<()>
-    where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
-        T: TryInto<Name>,
-        T::Error: fmt::Display,
-    {
-        let path = into_name(path)?;
-        let target = into_name(target)?;
-        let mut header = Header::new_ustar();
-        header.set_mode(DEFAULT_FILE_MODE);
-        header.set_entry_type(EntryType::Link)?;
-        header.set_size(0);
-        let mut pax_extensions = Vec::new();
-        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
-        prepare_header_hard_link(&mut header, &target, &mut pax_extensions)?;
-        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-        validate_header_for_write(&header)?;
-        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
-        header.set_cksum();
-        append_entry(self.get_mut(), &header, &[][..]).await
+    /// Adds a generated hard-link entry, using PAX for an overlong or non-ASCII value.
+    pub async fn append_hard_link<N: AsRef<Path>, T: AsRef<Path>>(
+        &mut self,
+        path: N,
+        target: T,
+    ) -> io::Result<()> {
+        let mut entry = generated_entry(
+            &checked(path.as_ref())?,
+            0,
+            EntryType::Link,
+            EntryMetadata::new(),
+            DEFAULT_FILE_MODE,
+        )?;
+        let target = checked(target.as_ref())?;
+        prepare_header_link(&mut entry.0, &mut entry.1, &target, PAX_HARD_LINK_FALLBACK);
+        append_generated(self.get_mut(), entry, &[][..]).await
     }
 
     /// Adds a new symbolic-link entry to this archive with the specified name and target.
@@ -282,35 +247,25 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// Valid non-ASCII or overlong values are written using PAX `path` or
     /// `linkpath` records. The entry type is set to [`EntryType::Symlink`] and
     /// the size is set to zero.
-    pub async fn append_symlink<N, T>(&mut self, path: N, target: T) -> io::Result<()>
-    where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
-        T: TryInto<LinkTarget>,
-        T::Error: fmt::Display,
-    {
-        let path = into_name(path)?;
-        let target = into_link_target(target)?;
-        let mut header = Header::new_ustar();
-        header.set_mode(DEFAULT_SYMLINK_MODE);
-        header.set_entry_type(EntryType::Symlink)?;
-        header.set_size(0);
-        let mut pax_extensions = Vec::new();
-        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
-        prepare_header_symlink_target(&mut header, &target, &mut pax_extensions)?;
-        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-        validate_header_for_write(&header)?;
-        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
-        header.set_cksum();
-        append_entry(self.get_mut(), &header, &[][..]).await
+    pub async fn append_symlink<N: AsRef<Path>, T: AsRef<Path>>(
+        &mut self,
+        path: N,
+        target: T,
+    ) -> io::Result<()> {
+        let mut entry = generated_entry(
+            &checked(path.as_ref())?,
+            0,
+            EntryType::Symlink,
+            EntryMetadata::new(),
+            DEFAULT_SYMLINK_MODE,
+        )?;
+        let target = link_target(target.as_ref())?;
+        prepare_header_link(&mut entry.0, &mut entry.1, &target, PAX_SYM_LINK_FALLBACK);
+        append_generated(self.get_mut(), entry, &[][..]).await
     }
 
     /// Adds a generated directory entry with conventional default permissions.
-    pub async fn append_directory<N>(&mut self, path: N) -> io::Result<()>
-    where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
-    {
+    pub async fn append_directory<N: AsRef<Path>>(&mut self, path: N) -> io::Result<()> {
         self.append_directory_with_metadata(path, EntryMetadata::new())
             .await
     }
@@ -322,21 +277,16 @@ impl<W: Write + Unpin + Send> Builder<W> {
         metadata: EntryMetadata,
     ) -> io::Result<()>
     where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
+        N: AsRef<Path>,
     {
-        let path = into_name(path)?;
-        let mut header = Header::new_ustar();
-        metadata.apply(&mut header, DEFAULT_DIRECTORY_MODE);
-        header.set_entry_type(EntryType::Directory)?;
-        header.set_size(0);
-        let mut pax_extensions = Vec::new();
-        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
-        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-        validate_header_for_write(&header)?;
-        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
-        header.set_cksum();
-        append_entry(self.get_mut(), &header, &[][..]).await
+        let entry = generated_entry(
+            &checked(path.as_ref())?,
+            0,
+            EntryType::Directory,
+            metadata,
+            DEFAULT_DIRECTORY_MODE,
+        )?;
+        append_generated(self.get_mut(), entry, &[][..]).await
     }
 
     /// Adds a file on the local filesystem to this archive.
@@ -370,7 +320,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
     pub async fn append_path<P: AsRef<Path>>(&mut self, path: P) -> io::Result<()> {
         let mode = self.mode;
         let follow = self.follow;
-        let name = Name::try_from(path.as_ref())?;
+        let name = checked(path.as_ref())?;
         append_path_with_name(self.get_mut(), path.as_ref(), &name, mode, follow).await?;
         Ok(())
     }
@@ -407,12 +357,11 @@ impl<W: Write + Unpin + Send> Builder<W> {
     pub async fn append_path_with_name<P, N>(&mut self, path: P, name: N) -> io::Result<()>
     where
         P: AsRef<Path>,
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
+        N: AsRef<Path>,
     {
         let mode = self.mode;
         let follow = self.follow;
-        let name = into_name(name)?;
+        let name = checked(name.as_ref())?;
         append_path_with_name(self.get_mut(), path.as_ref(), &name, mode, follow).await?;
         Ok(())
     }
@@ -447,13 +396,13 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_file<N>(&mut self, path: N, file: &mut fs::File) -> io::Result<()>
-    where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
-    {
+    pub async fn append_file<N: AsRef<Path>>(
+        &mut self,
+        path: N,
+        file: &mut fs::File,
+    ) -> io::Result<()> {
         let mode = self.mode;
-        let path = into_name(path)?;
+        let path = checked(path.as_ref())?;
         append_file(self.get_mut(), &path, file, mode).await?;
         Ok(())
     }
@@ -489,12 +438,11 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// ```
     pub async fn append_dir<N, P>(&mut self, path: N, src_path: P) -> io::Result<()>
     where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
+        N: AsRef<Path>,
         P: AsRef<Path>,
     {
         let mode = self.mode;
-        let path = into_name(path)?;
+        let path = checked(path.as_ref())?;
         append_dir(self.get_mut(), &path, src_path.as_ref(), mode).await?;
         Ok(())
     }
@@ -529,26 +477,22 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// ```
     pub async fn append_dir_all<N, P>(&mut self, path: N, src_path: P) -> io::Result<()>
     where
-        N: TryInto<Name>,
-        N::Error: fmt::Display,
+        N: AsRef<Path>,
         P: AsRef<Path>,
     {
         let mode = self.mode;
         let follow = self.follow;
-        let path = into_name(path)?;
-        append_dir_all(self.get_mut(), Some(&path), src_path.as_ref(), mode, follow).await?;
-        Ok(())
-    }
-
-    /// Adds a directory's contents recursively at the root of this archive.
-    ///
-    /// Unlike [`Builder::append_dir_all`], this method does not add an entry
-    /// for `src_path` itself and derives validated archive names for its
-    /// descendants.
-    pub async fn append_dir_all_at_root<P: AsRef<Path>>(&mut self, src_path: P) -> io::Result<()> {
-        let mode = self.mode;
-        let follow = self.follow;
-        append_dir_all(self.get_mut(), None, src_path.as_ref(), mode, follow).await?;
+        let path = (!path.as_ref().as_os_str().is_empty())
+            .then(|| checked(path.as_ref()))
+            .transpose()?;
+        append_dir_all(
+            self.get_mut(),
+            path.as_deref(),
+            src_path.as_ref(),
+            mode,
+            follow,
+        )
+        .await?;
         Ok(())
     }
 
@@ -594,103 +538,64 @@ const PAX_PAYLOAD_PATH: &str = "pax-entry";
 const PAX_HARD_LINK_FALLBACK: &[u8] = b"pax-hard-link";
 const PAX_SYM_LINK_FALLBACK: &[u8] = b"pax-sym-link";
 
-struct PaxExtension {
-    key: &'static [u8],
-    value: Vec<u8>,
+type PaxExtensions = Vec<(&'static str, String)>;
+type GeneratedEntry = (Header, PaxExtensions);
+
+fn generated_entry(
+    path: &str,
+    size: u64,
+    entry_type: EntryType,
+    metadata: EntryMetadata,
+    default_mode: u32,
+) -> io::Result<GeneratedEntry> {
+    let mut header = Header::new_ustar();
+    metadata.apply(&mut header, default_mode);
+    header.set_size(size);
+    header.set_entry_type(entry_type);
+    let mut extensions = Vec::new();
+    prepare_header_path(&mut header, path, &mut extensions);
+    prepare_header_numeric_fields(&mut header, &mut extensions)?;
+    Ok((header, extensions))
 }
 
-fn validate_header_for_write(header: &Header) -> io::Result<()> {
-    validate_header_format_for_write(header)?;
-    if header_has_base256_numeric_fields(header) {
-        return Err(other(
-            "cannot append a header with base-256 numeric fields to a USTAR/PAX archive",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_ustar_header(header: &Header) -> io::Result<()> {
-    if header.as_ustar().is_none() {
-        return Err(other("cannot append a non-USTAR header"));
-    }
-    Ok(())
-}
-
-fn validate_header_format_for_write(header: &Header) -> io::Result<()> {
-    validate_ustar_header(header)?;
-
-    let entry_type = header.entry_type();
-    if !entry_type.is_ustar_or_pax_writer() {
-        if entry_type.is_gnu_longname()
-            || entry_type.is_gnu_longlink()
-            || entry_type.is_gnu_sparse()
-        {
-            return Err(other("cannot append a GNU extension header"));
-        }
-        return Err(other("cannot append an unknown extension header"));
-    }
-
-    Ok(())
-}
-
-fn header_has_base256_numeric_fields(header: &Header) -> bool {
-    fn is_base256(field: &[u8]) -> bool {
-        field.first().is_some_and(|byte| byte & 0x80 != 0)
-    }
-
-    let old = header.as_old();
-    is_base256(&old.mode)
-        || is_base256(&old.uid)
-        || is_base256(&old.gid)
-        || is_base256(&old.size)
-        || is_base256(&old.mtime)
-        || header
-            .as_ustar()
-            .is_some_and(|ustar| is_base256(&ustar.dev_major) || is_base256(&ustar.dev_minor))
+async fn append_generated<Dst: Write + Unpin + ?Sized, Data: Read + Unpin>(
+    dst: &mut Dst,
+    (mut header, extensions): GeneratedEntry,
+    data: Data,
+) -> io::Result<()> {
+    append_pax_extensions(dst, &extensions).await?;
+    header.set_cksum();
+    append_entry(dst, &header, data).await
 }
 
 async fn append_pax_extensions<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    extensions: &[PaxExtension],
+    extensions: &PaxExtensions,
 ) -> io::Result<()> {
     if extensions.is_empty() {
         return Ok(());
     }
 
     let mut data = Vec::new();
-    for extension in extensions {
-        append_pax_record(&mut data, extension.key, &extension.value)?;
+    for (key, value) in extensions {
+        append_pax_record(&mut data, key, value);
     }
 
     let mut header = Header::new_ustar();
-    let path = Name::try_from(PAX_HEADER_PATH)?;
-    header.set_path(&path)?;
-    header.set_mode(0o644);
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
+    header.set_path(PAX_HEADER_PATH)?;
+    EntryMetadata::new().apply(&mut header, DEFAULT_FILE_MODE);
     header.set_size(data.len() as u64);
-    header.set_entry_type_unchecked(EntryType::XHeader);
-    validate_header_for_write(&header)?;
+    header.set_entry_type(EntryType::XHeader);
     header.set_cksum();
 
     append_entry(dst, &header, &data[..]).await
 }
 
-fn append_pax_record(dst: &mut Vec<u8>, key: &[u8], value: &[u8]) -> io::Result<()> {
-    let record_content_len = key
-        .len()
-        .checked_add(value.len())
-        .and_then(|len| len.checked_add(3))
-        .ok_or_else(|| other("pax extension is too long"))?;
-    let mut record_len = record_content_len
-        .checked_add(1)
-        .ok_or_else(|| other("pax extension is too long"))?;
-
+fn append_pax_record(dst: &mut Vec<u8>, key: &str, value: &str) {
+    let record_content_len = key.len() + value.len() + 3;
+    let mut record_len = record_content_len + 1;
     loop {
-        let next_len = record_content_len
-            .checked_add(record_len.to_string().len())
-            .ok_or_else(|| other("pax extension is too long"))?;
+        let next_len = record_content_len + record_len.to_string().len();
         if next_len == record_len {
             break;
         }
@@ -699,102 +604,57 @@ fn append_pax_record(dst: &mut Vec<u8>, key: &[u8], value: &[u8]) -> io::Result<
 
     dst.extend_from_slice(record_len.to_string().as_bytes());
     dst.push(b' ');
-    dst.extend_from_slice(key);
+    dst.extend_from_slice(key.as_bytes());
     dst.push(b'=');
-    dst.extend_from_slice(value);
+    dst.extend_from_slice(value.as_bytes());
     dst.push(b'\n');
-    Ok(())
 }
 
-fn push_pax_extension(extensions: &mut Vec<PaxExtension>, key: &'static [u8], value: Vec<u8>) {
-    extensions.push(PaxExtension { key, value });
-}
-
-fn push_pax_numeric_extension(extensions: &mut Vec<PaxExtension>, key: &'static [u8], value: u64) {
-    push_pax_extension(extensions, key, value.to_string().into_bytes());
-}
-
-fn prepare_header_path(
-    header: &mut Header,
-    path: &Name,
-    pax_extensions: &mut Vec<PaxExtension>,
-) -> io::Result<()> {
-    clear_header_path(header)?;
-    if header.set_path(path).is_err() {
-        clear_header_path(header)?;
-        let fallback = Name::try_from(PAX_PAYLOAD_PATH)?;
-        header.set_path(&fallback)?;
-        push_pax_extension(pax_extensions, b"path", path.as_bytes().to_vec());
+fn prepare_header_path(header: &mut Header, path: &str, pax_extensions: &mut PaxExtensions) {
+    if !path.is_ascii() || header.set_path(path).is_err() {
+        let ustar = header.as_ustar_mut().expect("writer uses USTAR headers");
+        ustar.name.fill(0);
+        ustar.prefix.fill(0);
+        header.set_path(PAX_PAYLOAD_PATH).unwrap();
+        pax_extensions.push(("path", path.to_owned()));
     }
-    Ok(())
 }
 
-fn clear_header_path(header: &mut Header) -> io::Result<()> {
-    let ustar = header
-        .as_ustar_mut()
-        .ok_or_else(|| other("cannot append a non-USTAR header"))?;
-    ustar.name.fill(0);
-    ustar.prefix.fill(0);
-    Ok(())
-}
-
-fn prepare_header_hard_link(
+fn prepare_header_link(
     header: &mut Header,
-    link_name: &Name,
-    pax_extensions: &mut Vec<PaxExtension>,
-) -> io::Result<()> {
+    pax_extensions: &mut PaxExtensions,
+    target: &str,
+    fallback: &[u8],
+) {
     header.as_old_mut().linkname.fill(0);
-    if header.set_hard_link_name(link_name).is_err() {
+    if !target.is_ascii() || header.set_link_name(target).is_err() {
         let linkname = &mut header.as_old_mut().linkname;
         linkname.fill(0);
-        linkname[..PAX_HARD_LINK_FALLBACK.len()].copy_from_slice(PAX_HARD_LINK_FALLBACK);
-        push_pax_extension(pax_extensions, b"linkpath", link_name.as_bytes().to_vec());
+        linkname[..fallback.len()].copy_from_slice(fallback);
+        pax_extensions.push(("linkpath", target.to_owned()));
     }
-    Ok(())
-}
-
-fn prepare_header_symlink_target(
-    header: &mut Header,
-    target: &LinkTarget,
-    pax_extensions: &mut Vec<PaxExtension>,
-) -> io::Result<()> {
-    header.as_old_mut().linkname.fill(0);
-    if header.set_symlink_target(target).is_err() {
-        let linkname = &mut header.as_old_mut().linkname;
-        linkname.fill(0);
-        linkname[..PAX_SYM_LINK_FALLBACK.len()].copy_from_slice(PAX_SYM_LINK_FALLBACK);
-        push_pax_extension(pax_extensions, b"linkpath", target.as_bytes().to_vec());
-    }
-    Ok(())
 }
 
 fn prepare_header_numeric_fields(
     header: &mut Header,
-    pax_extensions: &mut Vec<PaxExtension>,
+    pax_extensions: &mut PaxExtensions,
 ) -> io::Result<()> {
     fn is_base256(field: &[u8]) -> bool {
         field.first().is_some_and(|byte| byte & 0x80 != 0)
     }
 
-    if is_base256(&header.as_old().size) {
-        push_pax_numeric_extension(pax_extensions, b"size", header.entry_size()?);
-        header.set_size(0);
+    macro_rules! pax_field {
+        ($field:ident, $get:ident, $set:ident) => {
+            if is_base256(&header.as_old().$field) {
+                pax_extensions.push((stringify!($field), header.$get()?.to_string()));
+                header.$set(0);
+            }
+        };
     }
-
-    if is_base256(&header.as_old().uid) {
-        push_pax_numeric_extension(pax_extensions, b"uid", header.uid()?);
-        header.set_uid(0);
-    }
-
-    if is_base256(&header.as_old().gid) {
-        push_pax_numeric_extension(pax_extensions, b"gid", header.gid()?);
-        header.set_gid(0);
-    }
-
-    if is_base256(&header.as_old().mtime) {
-        push_pax_numeric_extension(pax_extensions, b"mtime", header.mtime()?);
-        header.set_mtime(0);
-    }
+    pax_field!(size, entry_size, set_size);
+    pax_field!(uid, uid, set_uid);
+    pax_field!(gid, gid, set_gid);
+    pax_field!(mtime, mtime, set_mtime);
 
     Ok(())
 }
@@ -802,7 +662,7 @@ fn prepare_header_numeric_fields(
 async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
     path: &Path,
-    name: &Name,
+    name: &str,
     mode: HeaderMode,
     follow: bool,
 ) -> io::Result<()> {
@@ -836,7 +696,7 @@ async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
         append_fs(dst, name, &stat, &mut io::empty(), mode, None).await?;
         Ok(())
     } else if stat.file_type().is_symlink() {
-        let link_name = LinkTarget::try_from(fs::read_link(path).await?)?;
+        let link_name = link_target(&fs::read_link(path).await?)?;
         append_fs(dst, name, &stat, &mut io::empty(), mode, Some(&link_name)).await?;
         Ok(())
     } else {
@@ -854,7 +714,7 @@ async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
 #[cfg(unix)]
 async fn append_special<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Name,
+    path: &str,
     stat: &Metadata,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -878,9 +738,9 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
     let mut header = Header::new_ustar();
     header.set_metadata_in_mode(stat, mode);
     let mut pax_extensions = Vec::new();
-    prepare_header_path(&mut header, path, &mut pax_extensions)?;
+    prepare_header_path(&mut header, path, &mut pax_extensions);
 
-    header.set_entry_type(entry_type)?;
+    header.set_entry_type(entry_type);
     let dev_id = stat.rdev();
     let dev_major = ((dev_id >> 32) & 0xffff_f000) | ((dev_id >> 8) & 0x0000_0fff);
     let dev_minor = ((dev_id >> 12) & 0xffff_ff00) | ((dev_id) & 0x0000_00ff);
@@ -888,17 +748,12 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
     header.set_device_minor(dev_minor as u32)?;
 
     prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-    validate_header_for_write(&header)?;
-    append_pax_extensions(dst, &pax_extensions).await?;
-    header.set_cksum();
-    dst.write_all(header.as_bytes()).await?;
-
-    Ok(())
+    append_generated(dst, (header, pax_extensions), &[][..]).await
 }
 
 async fn append_file<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Name,
+    path: &str,
     file: &mut fs::File,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -909,7 +764,7 @@ async fn append_file<Dst: Write + Unpin + ?Sized>(
 
 async fn append_dir<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Name,
+    path: &str,
     src_path: &Path,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -920,32 +775,32 @@ async fn append_dir<Dst: Write + Unpin + ?Sized>(
 
 async fn append_fs<Dst: Write + Unpin + ?Sized, R: Read + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Name,
+    path: &str,
     meta: &Metadata,
     read: &mut R,
     mode: HeaderMode,
-    link_name: Option<&LinkTarget>,
+    link_name: Option<&str>,
 ) -> io::Result<()> {
     let mut header = Header::new_ustar();
     let mut pax_extensions = Vec::new();
 
-    prepare_header_path(&mut header, path, &mut pax_extensions)?;
+    prepare_header_path(&mut header, path, &mut pax_extensions);
     header.set_metadata_in_mode(meta, mode);
     if let Some(link_name) = link_name {
-        prepare_header_symlink_target(&mut header, link_name, &mut pax_extensions)?;
+        prepare_header_link(
+            &mut header,
+            &mut pax_extensions,
+            link_name,
+            PAX_SYM_LINK_FALLBACK,
+        );
     }
     prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
-    validate_header_for_write(&header)?;
-    append_pax_extensions(dst, &pax_extensions).await?;
-    header.set_cksum();
-    append_entry(dst, &header, read).await?;
-
-    Ok(())
+    append_generated(dst, (header, pax_extensions), read).await
 }
 
 async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: Option<&Name>,
+    path: Option<&str>,
     src_path: &Path,
     mode: HeaderMode,
     follow: bool,
@@ -954,10 +809,10 @@ async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
     while let Some((src, is_dir, is_symlink)) = stack.pop() {
         let relative = src.strip_prefix(src_path).unwrap();
         let dest = match (path, relative.as_os_str().is_empty()) {
-            (Some(prefix), true) => Some(prefix.clone()),
-            (Some(prefix), false) => Some(Name::try_from(prefix.as_path().join(relative))?),
+            (Some(prefix), true) => Some(prefix.to_owned()),
+            (Some(prefix), false) => Some(checked(&Path::new(prefix).join(relative))?),
             (None, true) => None,
-            (None, false) => Some(Name::try_from(relative)?),
+            (None, false) => Some(checked(relative)?),
         };
 
         // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
@@ -973,7 +828,7 @@ async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
             }
         } else if !follow && is_symlink {
             let stat = fs::symlink_metadata(&src).await?;
-            let link_name = LinkTarget::try_from(fs::read_link(&src).await?)?;
+            let link_name = link_target(&fs::read_link(&src).await?)?;
             append_fs(
                 dst,
                 dest.as_ref().expect("recursive child has an archive name"),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,11 @@
 use crate::{
-    header::{path2bytes, HeaderMode},
+    header::{link_name2pax_bytes, path2pax_bytes, HeaderMode},
     other, EntryType, Header,
 };
-use std::{fs::Metadata, path::Path, str};
+use std::{fs::Metadata, path::Path};
 use tokio::{
     fs,
-    io::{self, AsyncRead as Read, AsyncReadExt, AsyncWrite as Write, AsyncWriteExt},
+    io::{self, AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt},
 };
 
 /// A structure for building archives
@@ -134,7 +134,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// use tokio_tar::{Builder, Header};
     ///
-    /// let mut header = Header::new_gnu();
+    /// let mut header = Header::new_ustar();
     /// header.set_path("foo")?;
     /// header.set_size(4);
     /// header.set_cksum();
@@ -152,6 +152,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
         header: &Header,
         mut data: R,
     ) -> io::Result<()> {
+        validate_header_for_write(header)?;
         append(self.get_mut(), header, &mut data).await?;
 
         Ok(())
@@ -160,7 +161,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// Adds a new entry to this archive with the specified path.
     ///
     /// This function will set the specified path in the given header, which may
-    /// require appending a GNU long-name extension entry to the archive first.
+    /// require appending a PAX extension entry to the archive first.
     /// The checksum for the header will be automatically updated via the
     /// `set_cksum` method after setting the path. No other metadata in the
     /// header will be modified.
@@ -189,7 +190,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// use tokio_tar::{Builder, Header};
     ///
-    /// let mut header = Header::new_gnu();
+    /// let mut header = Header::new_ustar();
     /// header.set_size(4);
     /// header.set_cksum();
     ///
@@ -207,7 +208,12 @@ impl<W: Write + Unpin + Send> Builder<W> {
         path: P,
         data: R,
     ) -> io::Result<()> {
-        prepare_header_path(self.get_mut(), header, path.as_ref()).await?;
+        validate_header_format_for_write(header)?;
+        let mut pax_extensions = Vec::new();
+        prepare_header_path(header, path.as_ref(), &mut pax_extensions)?;
+        prepare_header_numeric_fields(header, &mut pax_extensions)?;
+        validate_header_for_write(header)?;
+        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
         header.set_cksum();
         self.append(header, data).await?;
 
@@ -456,6 +462,192 @@ async fn append<Dst: Write + Unpin + ?Sized, Data: Read + Unpin + ?Sized>(
     Ok(())
 }
 
+const PAX_HEADER_PATH: &str = "PaxHeaders/pax-entry";
+const PAX_PAYLOAD_PATH: &str = "pax-entry";
+
+struct PaxExtension {
+    key: &'static [u8],
+    value: Vec<u8>,
+}
+
+fn validate_header_for_write(header: &Header) -> io::Result<()> {
+    validate_header_format_for_write(header)?;
+    if header_has_base256_numeric_fields(header) {
+        return Err(other(
+            "cannot append a header with base-256 numeric fields to a USTAR/PAX archive",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_header_format_for_write(header: &Header) -> io::Result<()> {
+    if header.as_ustar().is_none() {
+        return Err(other("cannot append a non-USTAR header"));
+    }
+
+    let entry_type = header.entry_type();
+    if !entry_type.is_ustar_or_pax_writer() {
+        if entry_type.is_gnu_longname()
+            || entry_type.is_gnu_longlink()
+            || entry_type.is_gnu_sparse()
+        {
+            return Err(other("cannot append a GNU extension header"));
+        }
+        return Err(other("cannot append an unknown extension header"));
+    }
+
+    Ok(())
+}
+
+fn header_has_base256_numeric_fields(header: &Header) -> bool {
+    fn is_base256(field: &[u8]) -> bool {
+        field.first().is_some_and(|byte| byte & 0x80 != 0)
+    }
+
+    let old = header.as_old();
+    is_base256(&old.mode)
+        || is_base256(&old.uid)
+        || is_base256(&old.gid)
+        || is_base256(&old.size)
+        || is_base256(&old.mtime)
+        || header
+            .as_ustar()
+            .is_some_and(|ustar| is_base256(&ustar.dev_major) || is_base256(&ustar.dev_minor))
+}
+
+async fn append_pax_extensions<Dst: Write + Unpin + ?Sized>(
+    dst: &mut Dst,
+    extensions: &[PaxExtension],
+) -> io::Result<()> {
+    if extensions.is_empty() {
+        return Ok(());
+    }
+
+    let mut data = Vec::new();
+    for extension in extensions {
+        append_pax_record(&mut data, extension.key, &extension.value)?;
+    }
+
+    let mut header = Header::new_ustar();
+    header.set_path(PAX_HEADER_PATH)?;
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(data.len() as u64);
+    header.set_entry_type_unchecked(EntryType::XHeader);
+    validate_header_for_write(&header)?;
+    header.set_cksum();
+
+    append(dst, &header, &mut &data[..]).await
+}
+
+fn append_pax_record(dst: &mut Vec<u8>, key: &[u8], value: &[u8]) -> io::Result<()> {
+    let record_content_len = key
+        .len()
+        .checked_add(value.len())
+        .and_then(|len| len.checked_add(3))
+        .ok_or_else(|| other("pax extension is too long"))?;
+    let mut record_len = record_content_len
+        .checked_add(1)
+        .ok_or_else(|| other("pax extension is too long"))?;
+
+    loop {
+        let next_len = record_content_len
+            .checked_add(record_len.to_string().len())
+            .ok_or_else(|| other("pax extension is too long"))?;
+        if next_len == record_len {
+            break;
+        }
+        record_len = next_len;
+    }
+
+    dst.extend_from_slice(record_len.to_string().as_bytes());
+    dst.push(b' ');
+    dst.extend_from_slice(key);
+    dst.push(b'=');
+    dst.extend_from_slice(value);
+    dst.push(b'\n');
+    Ok(())
+}
+
+fn push_pax_extension(extensions: &mut Vec<PaxExtension>, key: &'static [u8], value: Vec<u8>) {
+    extensions.push(PaxExtension { key, value });
+}
+
+fn push_pax_numeric_extension(extensions: &mut Vec<PaxExtension>, key: &'static [u8], value: u64) {
+    push_pax_extension(extensions, key, value.to_string().into_bytes());
+}
+
+fn prepare_header_path(
+    header: &mut Header,
+    path: &Path,
+    pax_extensions: &mut Vec<PaxExtension>,
+) -> io::Result<()> {
+    clear_header_path(header)?;
+    if header.set_path(path).is_err() {
+        let data = path2pax_bytes(path)?;
+        clear_header_path(header)?;
+        header.set_path(PAX_PAYLOAD_PATH)?;
+        push_pax_extension(pax_extensions, b"path", data);
+    }
+    Ok(())
+}
+
+fn clear_header_path(header: &mut Header) -> io::Result<()> {
+    let ustar = header
+        .as_ustar_mut()
+        .ok_or_else(|| other("cannot append a non-USTAR header"))?;
+    ustar.name.fill(0);
+    ustar.prefix.fill(0);
+    Ok(())
+}
+
+fn prepare_header_link(
+    header: &mut Header,
+    link_name: &Path,
+    pax_extensions: &mut Vec<PaxExtension>,
+) -> io::Result<()> {
+    header.as_old_mut().linkname.fill(0);
+    if header.set_link_name(link_name).is_err() {
+        let data = link_name2pax_bytes(link_name)?;
+        header.as_old_mut().linkname.fill(0);
+        push_pax_extension(pax_extensions, b"linkpath", data);
+    }
+    Ok(())
+}
+
+fn prepare_header_numeric_fields(
+    header: &mut Header,
+    pax_extensions: &mut Vec<PaxExtension>,
+) -> io::Result<()> {
+    fn is_base256(field: &[u8]) -> bool {
+        field.first().is_some_and(|byte| byte & 0x80 != 0)
+    }
+
+    if is_base256(&header.as_old().size) {
+        push_pax_numeric_extension(pax_extensions, b"size", header.entry_size()?);
+        header.set_size(0);
+    }
+
+    if is_base256(&header.as_old().uid) {
+        push_pax_numeric_extension(pax_extensions, b"uid", header.uid()?);
+        header.set_uid(0);
+    }
+
+    if is_base256(&header.as_old().gid) {
+        push_pax_numeric_extension(pax_extensions, b"gid", header.gid()?);
+        header.set_gid(0);
+    }
+
+    if is_base256(&header.as_old().mtime) {
+        push_pax_numeric_extension(pax_extensions, b"mtime", header.mtime()?);
+        header.set_mtime(0);
+    }
+
+    Ok(())
+}
+
 async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
     path: &Path,
@@ -544,17 +736,21 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
         return Err(other(&format!("{} has unknown file type", path.display())));
     }
 
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
     header.set_metadata_in_mode(stat, mode);
-    prepare_header_path(dst, &mut header, path).await?;
+    let mut pax_extensions = Vec::new();
+    prepare_header_path(&mut header, path, &mut pax_extensions)?;
 
-    header.set_entry_type(entry_type);
+    header.set_entry_type(entry_type)?;
     let dev_id = stat.rdev();
     let dev_major = ((dev_id >> 32) & 0xffff_f000) | ((dev_id >> 8) & 0x0000_0fff);
     let dev_minor = ((dev_id >> 12) & 0xffff_ff00) | ((dev_id) & 0x0000_00ff);
     header.set_device_major(dev_major as u32)?;
     header.set_device_minor(dev_minor as u32)?;
 
+    prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+    validate_header_for_write(&header)?;
+    append_pax_extensions(dst, &pax_extensions).await?;
     header.set_cksum();
     dst.write_all(header.as_bytes()).await?;
 
@@ -583,75 +779,6 @@ async fn append_dir<Dst: Write + Unpin + ?Sized>(
     Ok(())
 }
 
-fn prepare_header(size: u64, entry_type: EntryType) -> Header {
-    let mut header = Header::new_gnu();
-    let name = b"././@LongLink";
-    header.as_gnu_mut().unwrap().name[..name.len()].clone_from_slice(&name[..]);
-    header.set_mode(0o644);
-    header.set_uid(0);
-    header.set_gid(0);
-    header.set_mtime(0);
-    // + 1 to be compliant with GNU tar
-    header.set_size(size + 1);
-    header.set_entry_type(entry_type);
-    header.set_cksum();
-    header
-}
-
-async fn prepare_header_path<Dst: Write + Unpin + ?Sized>(
-    dst: &mut Dst,
-    header: &mut Header,
-    path: &Path,
-) -> io::Result<()> {
-    // Try to encode the path directly in the header, but if it ends up not
-    // working (probably because it's too long) then try to use the GNU-specific
-    // long name extension by emitting an entry which indicates that it's the
-    // filename.
-    if let Err(e) = header.set_path(path) {
-        let data = path2bytes(path)?;
-        let max = header.as_old().name.len();
-        //  Since e isn't specific enough to let us know the path is indeed too
-        //  long, verify it first before using the extension.
-        if data.len() < max {
-            return Err(e);
-        }
-        let header2 = prepare_header(data.len() as u64, EntryType::GNULongName);
-        // null-terminated string
-        let mut data2 = data.chain(io::repeat(0).take(1));
-        append(dst, &header2, &mut data2).await?;
-
-        // Truncate the path to store in the header we're about to emit to
-        // ensure we've got something at least mentioned. Note that we use
-        // `str`-encoding to be compatible with Windows, but in general the
-        // entry in the header itself shouldn't matter too much since extraction
-        // doesn't look at it.
-        let truncated = match str::from_utf8(&data[..max]) {
-            Ok(s) => s,
-            Err(e) => str::from_utf8(&data[..e.valid_up_to()]).unwrap(),
-        };
-        header.set_truncated_path_for_gnu_header(truncated)?;
-    }
-    Ok(())
-}
-
-async fn prepare_header_link<Dst: Write + Unpin + ?Sized>(
-    dst: &mut Dst,
-    header: &mut Header,
-    link_name: &Path,
-) -> io::Result<()> {
-    // Same as previous function but for linkname
-    if let Err(e) = header.set_link_name(link_name) {
-        let data = path2bytes(link_name)?;
-        if data.len() < header.as_old().linkname.len() {
-            return Err(e);
-        }
-        let header2 = prepare_header(data.len() as u64, EntryType::GNULongLink);
-        let mut data2 = data.chain(io::repeat(0).take(1));
-        append(dst, &header2, &mut data2).await?;
-    }
-    Ok(())
-}
-
 async fn append_fs<Dst: Write + Unpin + ?Sized, R: Read + Unpin + ?Sized>(
     dst: &mut Dst,
     path: &Path,
@@ -660,13 +787,17 @@ async fn append_fs<Dst: Write + Unpin + ?Sized, R: Read + Unpin + ?Sized>(
     mode: HeaderMode,
     link_name: Option<&Path>,
 ) -> io::Result<()> {
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
+    let mut pax_extensions = Vec::new();
 
-    prepare_header_path(dst, &mut header, path).await?;
+    prepare_header_path(&mut header, path, &mut pax_extensions)?;
     header.set_metadata_in_mode(meta, mode);
     if let Some(link_name) = link_name {
-        prepare_header_link(dst, &mut header, link_name).await?;
+        prepare_header_link(&mut header, link_name, &mut pax_extensions)?;
     }
+    prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+    validate_header_for_write(&header)?;
+    append_pax_extensions(dst, &pax_extensions).await?;
     header.set_cksum();
     append(dst, &header, read).await?;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,8 +1,9 @@
 use crate::{
-    header::{link_name2pax_bytes, path2pax_bytes, HeaderMode},
-    other, EntryType, Header,
+    header::HeaderMode,
+    name::{into_link_target, into_name},
+    other, EntryType, Header, LinkTarget, Name,
 };
-use std::{fs::Metadata, path::Path};
+use std::{fmt, fs::Metadata, path::Path};
 use tokio::{
     fs,
     io::{self, AsyncRead as Read, AsyncWrite as Write, AsyncWriteExt},
@@ -20,7 +21,61 @@ pub struct Builder<W: Write + Unpin + Send> {
     cancellation: Option<tokio::sync::oneshot::Sender<W>>,
 }
 
+/// Metadata overrides for a generated entry written through [`Builder`].
+///
+/// Filesystem-based builder methods take metadata from their source path.
+/// Generated entry methods use conventional permissions unless `mode` is
+/// overridden; the other numeric fields default to zero.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct EntryMetadata {
+    mode: Option<u32>,
+    uid: u64,
+    gid: u64,
+    mtime: u64,
+}
+
+impl EntryMetadata {
+    /// Creates empty metadata overrides.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the Unix mode bits for the entry.
+    pub fn mode(mut self, mode: u32) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Sets the owner user ID for the entry.
+    pub fn uid(mut self, uid: u64) -> Self {
+        self.uid = uid;
+        self
+    }
+
+    /// Sets the owner group ID for the entry.
+    pub fn gid(mut self, gid: u64) -> Self {
+        self.gid = gid;
+        self
+    }
+
+    /// Sets the modification time, as Unix seconds, for the entry.
+    pub fn mtime(mut self, mtime: u64) -> Self {
+        self.mtime = mtime;
+        self
+    }
+
+    fn apply(self, header: &mut Header, default_mode: u32) {
+        header.set_mode(self.mode.unwrap_or(default_mode));
+        header.set_uid(self.uid);
+        header.set_gid(self.gid);
+        header.set_mtime(self.mtime);
+    }
+}
+
 const TERMINATION: &[u8; 1024] = &[0; 1024];
+const DEFAULT_FILE_MODE: u32 = 0o644;
+const DEFAULT_DIRECTORY_MODE: u32 = 0o755;
+const DEFAULT_SYMLINK_MODE: u32 = 0o777;
 
 impl<W: Write + Unpin + Send + 'static> Builder<W> {
     /// Create a new archive builder with the underlying object as the
@@ -64,7 +119,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
 
     /// Changes the HeaderMode that will be used when reading fs Metadata for
     /// methods that implicitly read metadata for an input Path. Notably, this
-    /// does _not_ apply to `append(Header)`.
+    /// does not apply to generated entries supplied with [`EntryMetadata`].
     pub fn mode(&mut self, mode: HeaderMode) {
         self.mode = mode;
     }
@@ -85,13 +140,7 @@ impl<W: Write + Unpin + Send> Builder<W> {
         self.obj.as_ref().unwrap()
     }
 
-    /// Gets mutable reference to the underlying object.
-    ///
-    /// Note that care must be taken while writing to the underlying
-    /// object. But, e.g. `get_mut().flush()` is claimed to be safe and
-    /// useful in the situations when one needs to be ensured that
-    /// tar entry was flushed to the disk.
-    pub fn get_mut(&mut self) -> &mut W {
+    fn get_mut(&mut self) -> &mut W {
         self.obj.as_mut().unwrap()
     }
 
@@ -107,13 +156,11 @@ impl<W: Write + Unpin + Send> Builder<W> {
         Ok(self.obj.take().unwrap())
     }
 
-    /// Adds a new entry to this archive.
+    /// Adds a generated regular-file entry to this archive.
     ///
-    /// This function will append the header specified, followed by contents of
-    /// the stream specified by `data`. To produce a valid archive the `size`
-    /// field of `header` must be the same as the length of the stream that's
-    /// being written. Additionally the checksum for the header should have been
-    /// set via the `set_cksum` method.
+    /// A PAX `path` extension is emitted when the validated [`Name`] is too
+    /// long for USTAR or contains non-ASCII UTF-8. `size` must equal the
+    /// number of bytes read from `data`.
     ///
     /// Note that this will not attempt to seek the archive to a valid position,
     /// so if the archive is in the middle of a read or some other similar
@@ -132,105 +179,61 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// #
-    /// use tokio_tar::{Builder, Header};
-    ///
-    /// let mut header = Header::new_ustar();
-    /// header.set_path("foo")?;
-    /// header.set_size(4);
-    /// header.set_cksum();
+    /// use tokio_tar::Builder;
     ///
     /// let mut data: &[u8] = &[1, 2, 3, 4];
     ///
     /// let mut ar = Builder::new(Vec::new());
-    /// ar.append(&header, data).await?;
+    /// ar.append_data("really/long/path/to/foo", 4, data).await?;
     /// let data = ar.into_inner().await?;
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append<R: Read + Unpin>(
-        &mut self,
-        header: &Header,
-        mut data: R,
-    ) -> io::Result<()> {
-        validate_header_for_write(header)?;
-        append(self.get_mut(), header, &mut data).await?;
-
-        Ok(())
+    pub async fn append_data<N, R>(&mut self, path: N, size: u64, data: R) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+        R: Read + Unpin,
+    {
+        self.append_data_with_metadata(path, size, EntryMetadata::new(), data)
+            .await
     }
 
-    /// Adds a new entry to this archive with the specified path.
-    ///
-    /// This function will set the specified path in the given header, which may
-    /// require appending a PAX extension entry to the archive first.
-    /// The checksum for the header will be automatically updated via the
-    /// `set_cksum` method after setting the path. No other metadata in the
-    /// header will be modified.
-    ///
-    /// Then it will append the header, followed by contents of the stream
-    /// specified by `data`. To produce a valid archive the `size` field of
-    /// `header` must be the same as the length of the stream that's being
-    /// written.
-    ///
-    /// Note that this will not attempt to seek the archive to a valid position,
-    /// so if the archive is in the middle of a read or some other similar
-    /// operation then this may corrupt the archive.
-    ///
-    /// Also note that after all entries have been written to an archive the
-    /// `finish` function needs to be called to finish writing the archive.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error for any intermittent I/O error which
-    /// occurs when either reading or writing.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { tokio::runtime::Runtime::new().unwrap().block_on(async {
-    /// #
-    /// use tokio_tar::{Builder, Header};
-    ///
-    /// let mut header = Header::new_ustar();
-    /// header.set_size(4);
-    /// header.set_cksum();
-    ///
-    /// let mut data: &[u8] = &[1, 2, 3, 4];
-    ///
-    /// let mut ar = Builder::new(Vec::new());
-    /// ar.append_data(&mut header, "really/long/path/to/foo", data).await?;
-    /// let data = ar.into_inner().await?;
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin>(
+    /// Adds a generated regular-file entry with explicitly supplied metadata.
+    pub async fn append_data_with_metadata<N, R>(
         &mut self,
-        header: &mut Header,
-        path: P,
+        path: N,
+        size: u64,
+        metadata: EntryMetadata,
         data: R,
-    ) -> io::Result<()> {
-        validate_header_format_for_write(header)?;
+    ) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+        R: Read + Unpin,
+    {
+        let path = into_name(path)?;
+        let mut header = Header::new_ustar();
+        metadata.apply(&mut header, DEFAULT_FILE_MODE);
+        header.set_size(size);
         let mut pax_extensions = Vec::new();
-        prepare_header_path(header, path.as_ref(), &mut pax_extensions)?;
-        prepare_header_numeric_fields(header, &mut pax_extensions)?;
-        validate_header_for_write(header)?;
+        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
+        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+        validate_header_for_write(&header)?;
         append_pax_extensions(self.get_mut(), &pax_extensions).await?;
         header.set_cksum();
-        self.append(header, data).await?;
-
-        Ok(())
+        append_entry(self.get_mut(), &header, data).await
     }
 
-    /// Adds a new link entry to this archive with the specified path and target.
+    /// Adds a new hard-link entry to this archive with the specified name and destination.
     ///
-    /// This function supports either a hard link or a symbolic link header. It
-    /// will set the specified path and link target in the header, appending a
-    /// PAX extension entry first when either value cannot fit in USTAR. The
-    /// checksum for the header will be automatically updated via the
-    /// `set_cksum` method. No other metadata in the header will be modified.
+    /// This function sets the specified member name and hard-link destination
+    /// in the header, appending a
+    /// PAX extension entry first when either value is too long for USTAR or
+    /// contains non-ASCII characters. The checksum for the header is updated
+    /// automatically.
     ///
-    /// The header entry type must be [`EntryType::Link`] or
-    /// [`EntryType::Symlink`]. Link entries do not carry archive data, so the
-    /// header size must be zero.
+    /// The entry type is set to [`EntryType::Link`] and the size is set to zero.
     ///
     /// # Errors
     ///
@@ -243,39 +246,97 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// #
-    /// use tokio_tar::{Builder, EntryType, Header};
-    ///
-    /// let mut header = Header::new_ustar();
-    /// header.set_entry_type(EntryType::Symlink)?;
-    /// header.set_size(0);
+    /// use tokio_tar::Builder;
     ///
     /// let mut ar = Builder::new(Vec::new());
-    /// ar.append_link(&mut header, "link", "really/long/link/target").await?;
+    /// ar.append_hard_link("link", "really/long/link/target").await?;
     /// let data = ar.into_inner().await?;
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_link<P: AsRef<Path>, T: AsRef<Path>>(
-        &mut self,
-        header: &mut Header,
-        path: P,
-        target: T,
-    ) -> io::Result<()> {
-        validate_header_format_for_write(header)?;
-        if !header.entry_type().is_hard_link() && !header.entry_type().is_symlink() {
-            return Err(other("cannot append a non-link header as a link"));
-        }
-
+    pub async fn append_hard_link<N, T>(&mut self, path: N, target: T) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+        T: TryInto<Name>,
+        T::Error: fmt::Display,
+    {
+        let path = into_name(path)?;
+        let target = into_name(target)?;
+        let mut header = Header::new_ustar();
+        header.set_mode(DEFAULT_FILE_MODE);
+        header.set_entry_type(EntryType::Link)?;
+        header.set_size(0);
         let mut pax_extensions = Vec::new();
-        prepare_header_path(header, path.as_ref(), &mut pax_extensions)?;
-        prepare_header_link(header, target.as_ref(), &mut pax_extensions)?;
-        prepare_header_numeric_fields(header, &mut pax_extensions)?;
-        validate_header_for_write(header)?;
+        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
+        prepare_header_hard_link(&mut header, &target, &mut pax_extensions)?;
+        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+        validate_header_for_write(&header)?;
         append_pax_extensions(self.get_mut(), &pax_extensions).await?;
         header.set_cksum();
-        self.append(header, &[][..]).await?;
+        append_entry(self.get_mut(), &header, &[][..]).await
+    }
 
-        Ok(())
+    /// Adds a new symbolic-link entry to this archive with the specified name and target.
+    ///
+    /// Valid non-ASCII or overlong values are written using PAX `path` or
+    /// `linkpath` records. The entry type is set to [`EntryType::Symlink`] and
+    /// the size is set to zero.
+    pub async fn append_symlink<N, T>(&mut self, path: N, target: T) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+        T: TryInto<LinkTarget>,
+        T::Error: fmt::Display,
+    {
+        let path = into_name(path)?;
+        let target = into_link_target(target)?;
+        let mut header = Header::new_ustar();
+        header.set_mode(DEFAULT_SYMLINK_MODE);
+        header.set_entry_type(EntryType::Symlink)?;
+        header.set_size(0);
+        let mut pax_extensions = Vec::new();
+        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
+        prepare_header_symlink_target(&mut header, &target, &mut pax_extensions)?;
+        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+        validate_header_for_write(&header)?;
+        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
+        header.set_cksum();
+        append_entry(self.get_mut(), &header, &[][..]).await
+    }
+
+    /// Adds a generated directory entry with conventional default permissions.
+    pub async fn append_directory<N>(&mut self, path: N) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+    {
+        self.append_directory_with_metadata(path, EntryMetadata::new())
+            .await
+    }
+
+    /// Adds a generated directory entry with explicitly supplied metadata.
+    pub async fn append_directory_with_metadata<N>(
+        &mut self,
+        path: N,
+        metadata: EntryMetadata,
+    ) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+    {
+        let path = into_name(path)?;
+        let mut header = Header::new_ustar();
+        metadata.apply(&mut header, DEFAULT_DIRECTORY_MODE);
+        header.set_entry_type(EntryType::Directory)?;
+        header.set_size(0);
+        let mut pax_extensions = Vec::new();
+        prepare_header_path(&mut header, &path, &mut pax_extensions)?;
+        prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
+        validate_header_for_write(&header)?;
+        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
+        header.set_cksum();
+        append_entry(self.get_mut(), &header, &[][..]).await
     }
 
     /// Adds a file on the local filesystem to this archive.
@@ -309,7 +370,8 @@ impl<W: Write + Unpin + Send> Builder<W> {
     pub async fn append_path<P: AsRef<Path>>(&mut self, path: P) -> io::Result<()> {
         let mode = self.mode;
         let follow = self.follow;
-        append_path_with_name(self.get_mut(), path.as_ref(), None, mode, follow).await?;
+        let name = Name::try_from(path.as_ref())?;
+        append_path_with_name(self.get_mut(), path.as_ref(), &name, mode, follow).await?;
         Ok(())
     }
 
@@ -342,21 +404,16 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_path_with_name<P: AsRef<Path>, N: AsRef<Path>>(
-        &mut self,
-        path: P,
-        name: N,
-    ) -> io::Result<()> {
+    pub async fn append_path_with_name<P, N>(&mut self, path: P, name: N) -> io::Result<()>
+    where
+        P: AsRef<Path>,
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+    {
         let mode = self.mode;
         let follow = self.follow;
-        append_path_with_name(
-            self.get_mut(),
-            path.as_ref(),
-            Some(name.as_ref()),
-            mode,
-            follow,
-        )
-        .await?;
+        let name = into_name(name)?;
+        append_path_with_name(self.get_mut(), path.as_ref(), &name, mode, follow).await?;
         Ok(())
     }
 
@@ -390,13 +447,14 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_file<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        file: &mut fs::File,
-    ) -> io::Result<()> {
+    pub async fn append_file<N>(&mut self, path: N, file: &mut fs::File) -> io::Result<()>
+    where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
+    {
         let mode = self.mode;
-        append_file(self.get_mut(), path.as_ref(), file, mode).await?;
+        let path = into_name(path)?;
+        append_file(self.get_mut(), &path, file, mode).await?;
         Ok(())
     }
 
@@ -429,13 +487,15 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_dir<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>
+    pub async fn append_dir<N, P>(&mut self, path: N, src_path: P) -> io::Result<()>
     where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
         P: AsRef<Path>,
-        Q: AsRef<Path>,
     {
         let mode = self.mode;
-        append_dir(self.get_mut(), path.as_ref(), src_path.as_ref(), mode).await?;
+        let path = into_name(path)?;
+        append_dir(self.get_mut(), &path, src_path.as_ref(), mode).await?;
         Ok(())
     }
 
@@ -467,21 +527,28 @@ impl<W: Write + Unpin + Send> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_dir_all<P, Q>(&mut self, path: P, src_path: Q) -> io::Result<()>
+    pub async fn append_dir_all<N, P>(&mut self, path: N, src_path: P) -> io::Result<()>
     where
+        N: TryInto<Name>,
+        N::Error: fmt::Display,
         P: AsRef<Path>,
-        Q: AsRef<Path>,
     {
         let mode = self.mode;
         let follow = self.follow;
-        append_dir_all(
-            self.get_mut(),
-            path.as_ref(),
-            src_path.as_ref(),
-            mode,
-            follow,
-        )
-        .await?;
+        let path = into_name(path)?;
+        append_dir_all(self.get_mut(), Some(&path), src_path.as_ref(), mode, follow).await?;
+        Ok(())
+    }
+
+    /// Adds a directory's contents recursively at the root of this archive.
+    ///
+    /// Unlike [`Builder::append_dir_all`], this method does not add an entry
+    /// for `src_path` itself and derives validated archive names for its
+    /// descendants.
+    pub async fn append_dir_all_at_root<P: AsRef<Path>>(&mut self, src_path: P) -> io::Result<()> {
+        let mode = self.mode;
+        let follow = self.follow;
+        append_dir_all(self.get_mut(), None, src_path.as_ref(), mode, follow).await?;
         Ok(())
     }
 
@@ -502,10 +569,10 @@ impl<W: Write + Unpin + Send> Builder<W> {
     }
 }
 
-async fn append<Dst: Write + Unpin + ?Sized, Data: Read + Unpin + ?Sized>(
+async fn append_entry<Dst: Write + Unpin + ?Sized, Data: Read + Unpin>(
     mut dst: &mut Dst,
     header: &Header,
-    mut data: &mut Data,
+    mut data: Data,
 ) -> io::Result<()> {
     dst.write_all(header.as_bytes()).await?;
     let len = io::copy(&mut data, &mut dst).await?;
@@ -522,12 +589,10 @@ async fn append<Dst: Write + Unpin + ?Sized, Data: Read + Unpin + ?Sized>(
 
 const PAX_HEADER_PATH: &str = "PaxHeaders/pax-entry";
 const PAX_PAYLOAD_PATH: &str = "pax-entry";
-// libarchive uses these special `linkname` values (in the USTAR header)
-// when adding a `linkpath` PAX extension.
-// Technically the value of the `linkname` is not important, since a PAX-compliant
-// reader should ignore it when the `linkpath` extension is present.
-const PAX_HARD_LINK_FALLBACK: &[u8] = b"././@LongHardLink";
-const PAX_SYM_LINK_FALLBACK: &[u8] = b"././@LongSymLink";
+// A PAX-compliant reader ignores these canonical ASCII fallbacks when a
+// `linkpath` extension is present.
+const PAX_HARD_LINK_FALLBACK: &[u8] = b"pax-hard-link";
+const PAX_SYM_LINK_FALLBACK: &[u8] = b"pax-sym-link";
 
 struct PaxExtension {
     key: &'static [u8],
@@ -544,10 +609,15 @@ fn validate_header_for_write(header: &Header) -> io::Result<()> {
     Ok(())
 }
 
-fn validate_header_format_for_write(header: &Header) -> io::Result<()> {
+fn validate_ustar_header(header: &Header) -> io::Result<()> {
     if header.as_ustar().is_none() {
         return Err(other("cannot append a non-USTAR header"));
     }
+    Ok(())
+}
+
+fn validate_header_format_for_write(header: &Header) -> io::Result<()> {
+    validate_ustar_header(header)?;
 
     let entry_type = header.entry_type();
     if !entry_type.is_ustar_or_pax_writer() {
@@ -593,7 +663,8 @@ async fn append_pax_extensions<Dst: Write + Unpin + ?Sized>(
     }
 
     let mut header = Header::new_ustar();
-    header.set_path(PAX_HEADER_PATH)?;
+    let path = Name::try_from(PAX_HEADER_PATH)?;
+    header.set_path(&path)?;
     header.set_mode(0o644);
     header.set_uid(0);
     header.set_gid(0);
@@ -603,7 +674,7 @@ async fn append_pax_extensions<Dst: Write + Unpin + ?Sized>(
     validate_header_for_write(&header)?;
     header.set_cksum();
 
-    append(dst, &header, &mut &data[..]).await
+    append_entry(dst, &header, &data[..]).await
 }
 
 fn append_pax_record(dst: &mut Vec<u8>, key: &[u8], value: &[u8]) -> io::Result<()> {
@@ -645,15 +716,15 @@ fn push_pax_numeric_extension(extensions: &mut Vec<PaxExtension>, key: &'static 
 
 fn prepare_header_path(
     header: &mut Header,
-    path: &Path,
+    path: &Name,
     pax_extensions: &mut Vec<PaxExtension>,
 ) -> io::Result<()> {
     clear_header_path(header)?;
     if header.set_path(path).is_err() {
-        let data = path2pax_bytes(path)?;
         clear_header_path(header)?;
-        header.set_path(PAX_PAYLOAD_PATH)?;
-        push_pax_extension(pax_extensions, b"path", data);
+        let fallback = Name::try_from(PAX_PAYLOAD_PATH)?;
+        header.set_path(&fallback)?;
+        push_pax_extension(pax_extensions, b"path", path.as_bytes().to_vec());
     }
     Ok(())
 }
@@ -667,23 +738,32 @@ fn clear_header_path(header: &mut Header) -> io::Result<()> {
     Ok(())
 }
 
-fn prepare_header_link(
+fn prepare_header_hard_link(
     header: &mut Header,
-    link_name: &Path,
+    link_name: &Name,
     pax_extensions: &mut Vec<PaxExtension>,
 ) -> io::Result<()> {
     header.as_old_mut().linkname.fill(0);
-    if header.set_link_name(link_name).is_err() {
-        let data = link_name2pax_bytes(link_name)?;
-        let fallback = if header.entry_type().is_hard_link() {
-            PAX_HARD_LINK_FALLBACK
-        } else {
-            PAX_SYM_LINK_FALLBACK
-        };
+    if header.set_hard_link_name(link_name).is_err() {
         let linkname = &mut header.as_old_mut().linkname;
         linkname.fill(0);
-        linkname[..fallback.len()].copy_from_slice(fallback);
-        push_pax_extension(pax_extensions, b"linkpath", data);
+        linkname[..PAX_HARD_LINK_FALLBACK.len()].copy_from_slice(PAX_HARD_LINK_FALLBACK);
+        push_pax_extension(pax_extensions, b"linkpath", link_name.as_bytes().to_vec());
+    }
+    Ok(())
+}
+
+fn prepare_header_symlink_target(
+    header: &mut Header,
+    target: &LinkTarget,
+    pax_extensions: &mut Vec<PaxExtension>,
+) -> io::Result<()> {
+    header.as_old_mut().linkname.fill(0);
+    if header.set_symlink_target(target).is_err() {
+        let linkname = &mut header.as_old_mut().linkname;
+        linkname.fill(0);
+        linkname[..PAX_SYM_LINK_FALLBACK.len()].copy_from_slice(PAX_SYM_LINK_FALLBACK);
+        push_pax_extension(pax_extensions, b"linkpath", target.as_bytes().to_vec());
     }
     Ok(())
 }
@@ -722,7 +802,7 @@ fn prepare_header_numeric_fields(
 async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
     path: &Path,
-    name: Option<&Path>,
+    name: &Name,
     mode: HeaderMode,
     follow: bool,
 ) -> io::Result<()> {
@@ -741,11 +821,10 @@ async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
             )
         })?
     };
-    let ar_name = name.unwrap_or(path);
     if stat.is_file() {
         append_fs(
             dst,
-            ar_name,
+            name,
             &stat,
             &mut fs::File::open(path).await?,
             mode,
@@ -754,24 +833,16 @@ async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
         .await?;
         Ok(())
     } else if stat.is_dir() {
-        append_fs(dst, ar_name, &stat, &mut io::empty(), mode, None).await?;
+        append_fs(dst, name, &stat, &mut io::empty(), mode, None).await?;
         Ok(())
     } else if stat.file_type().is_symlink() {
-        let link_name = fs::read_link(path).await?;
-        append_fs(
-            dst,
-            ar_name,
-            &stat,
-            &mut io::empty(),
-            mode,
-            Some(&link_name),
-        )
-        .await?;
+        let link_name = LinkTarget::try_from(fs::read_link(path).await?)?;
+        append_fs(dst, name, &stat, &mut io::empty(), mode, Some(&link_name)).await?;
         Ok(())
     } else {
         #[cfg(unix)]
         {
-            append_special(dst, path, &stat, mode).await
+            append_special(dst, name, &stat, mode).await
         }
         #[cfg(not(unix))]
         {
@@ -783,7 +854,7 @@ async fn append_path_with_name<Dst: Write + Unpin + ?Sized>(
 #[cfg(unix)]
 async fn append_special<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Path,
+    path: &Name,
     stat: &Metadata,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -793,10 +864,7 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
     let entry_type;
     if file_type.is_socket() {
         // sockets can't be archived
-        return Err(other(&format!(
-            "{}: socket can not be archived",
-            path.display()
-        )));
+        return Err(other(&format!("{}: socket can not be archived", path)));
     } else if file_type.is_fifo() {
         entry_type = EntryType::Fifo;
     } else if file_type.is_char_device() {
@@ -804,7 +872,7 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
     } else if file_type.is_block_device() {
         entry_type = EntryType::Block;
     } else {
-        return Err(other(&format!("{} has unknown file type", path.display())));
+        return Err(other(&format!("{} has unknown file type", path)));
     }
 
     let mut header = Header::new_ustar();
@@ -830,7 +898,7 @@ async fn append_special<Dst: Write + Unpin + ?Sized>(
 
 async fn append_file<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Path,
+    path: &Name,
     file: &mut fs::File,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -841,7 +909,7 @@ async fn append_file<Dst: Write + Unpin + ?Sized>(
 
 async fn append_dir<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Path,
+    path: &Name,
     src_path: &Path,
     mode: HeaderMode,
 ) -> io::Result<()> {
@@ -852,11 +920,11 @@ async fn append_dir<Dst: Write + Unpin + ?Sized>(
 
 async fn append_fs<Dst: Write + Unpin + ?Sized, R: Read + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Path,
+    path: &Name,
     meta: &Metadata,
     read: &mut R,
     mode: HeaderMode,
-    link_name: Option<&Path>,
+    link_name: Option<&LinkTarget>,
 ) -> io::Result<()> {
     let mut header = Header::new_ustar();
     let mut pax_extensions = Vec::new();
@@ -864,27 +932,33 @@ async fn append_fs<Dst: Write + Unpin + ?Sized, R: Read + Unpin + ?Sized>(
     prepare_header_path(&mut header, path, &mut pax_extensions)?;
     header.set_metadata_in_mode(meta, mode);
     if let Some(link_name) = link_name {
-        prepare_header_link(&mut header, link_name, &mut pax_extensions)?;
+        prepare_header_symlink_target(&mut header, link_name, &mut pax_extensions)?;
     }
     prepare_header_numeric_fields(&mut header, &mut pax_extensions)?;
     validate_header_for_write(&header)?;
     append_pax_extensions(dst, &pax_extensions).await?;
     header.set_cksum();
-    append(dst, &header, read).await?;
+    append_entry(dst, &header, read).await?;
 
     Ok(())
 }
 
 async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
     dst: &mut Dst,
-    path: &Path,
+    path: Option<&Name>,
     src_path: &Path,
     mode: HeaderMode,
     follow: bool,
 ) -> io::Result<()> {
     let mut stack = vec![(src_path.to_path_buf(), true, false)];
     while let Some((src, is_dir, is_symlink)) = stack.pop() {
-        let dest = path.join(src.strip_prefix(src_path).unwrap());
+        let relative = src.strip_prefix(src_path).unwrap();
+        let dest = match (path, relative.as_os_str().is_empty()) {
+            (Some(prefix), true) => Some(prefix.clone()),
+            (Some(prefix), false) => Some(Name::try_from(prefix.as_path().join(relative))?),
+            (None, true) => None,
+            (None, false) => Some(Name::try_from(relative)?),
+        };
 
         // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
         if is_dir || (is_symlink && follow && src.is_dir()) {
@@ -894,23 +968,32 @@ async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
                 let file_type = entry.file_type().await?;
                 stack.push((entry.path(), file_type.is_dir(), file_type.is_symlink()));
             }
-            if dest != Path::new("") {
-                append_dir(dst, &dest, &src, mode).await?;
+            if let Some(dest) = &dest {
+                append_dir(dst, dest, &src, mode).await?;
             }
         } else if !follow && is_symlink {
             let stat = fs::symlink_metadata(&src).await?;
-            let link_name = fs::read_link(&src).await?;
-            append_fs(dst, &dest, &stat, &mut io::empty(), mode, Some(&link_name)).await?;
+            let link_name = LinkTarget::try_from(fs::read_link(&src).await?)?;
+            append_fs(
+                dst,
+                dest.as_ref().expect("recursive child has an archive name"),
+                &stat,
+                &mut io::empty(),
+                mode,
+                Some(&link_name),
+            )
+            .await?;
         } else {
+            let dest = dest.as_ref().expect("recursive child has an archive name");
             #[cfg(unix)]
             {
                 let stat = fs::metadata(&src).await?;
                 if !stat.is_file() {
-                    append_special(dst, &dest, &stat, mode).await?;
+                    append_special(dst, dest, &stat, mode).await?;
                     continue;
                 }
             }
-            append_file(dst, &dest, &mut fs::File::open(src).await?, mode).await?;
+            append_file(dst, dest, &mut fs::File::open(src).await?, mode).await?;
         }
     }
     Ok(())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -220,6 +220,64 @@ impl<W: Write + Unpin + Send> Builder<W> {
         Ok(())
     }
 
+    /// Adds a new link entry to this archive with the specified path and target.
+    ///
+    /// This function supports either a hard link or a symbolic link header. It
+    /// will set the specified path and link target in the header, appending a
+    /// PAX extension entry first when either value cannot fit in USTAR. The
+    /// checksum for the header will be automatically updated via the
+    /// `set_cksum` method. No other metadata in the header will be modified.
+    ///
+    /// The header entry type must be [`EntryType::Link`] or
+    /// [`EntryType::Symlink`]. Link entries do not carry archive data, so the
+    /// header size must be zero.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error for any intermittent I/O error which
+    /// occurs when writing, or if the header cannot describe a USTAR/PAX link
+    /// entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// #
+    /// use tokio_tar::{Builder, EntryType, Header};
+    ///
+    /// let mut header = Header::new_ustar();
+    /// header.set_entry_type(EntryType::Symlink)?;
+    /// header.set_size(0);
+    ///
+    /// let mut ar = Builder::new(Vec::new());
+    /// ar.append_link(&mut header, "link", "really/long/link/target").await?;
+    /// let data = ar.into_inner().await?;
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn append_link<P: AsRef<Path>, T: AsRef<Path>>(
+        &mut self,
+        header: &mut Header,
+        path: P,
+        target: T,
+    ) -> io::Result<()> {
+        validate_header_format_for_write(header)?;
+        if !header.entry_type().is_hard_link() && !header.entry_type().is_symlink() {
+            return Err(other("cannot append a non-link header as a link"));
+        }
+
+        let mut pax_extensions = Vec::new();
+        prepare_header_path(header, path.as_ref(), &mut pax_extensions)?;
+        prepare_header_link(header, target.as_ref(), &mut pax_extensions)?;
+        prepare_header_numeric_fields(header, &mut pax_extensions)?;
+        validate_header_for_write(header)?;
+        append_pax_extensions(self.get_mut(), &pax_extensions).await?;
+        header.set_cksum();
+        self.append(header, &[][..]).await?;
+
+        Ok(())
+    }
+
     /// Adds a file on the local filesystem to this archive.
     ///
     /// This function will open the file specified by `path` and insert the file
@@ -464,6 +522,12 @@ async fn append<Dst: Write + Unpin + ?Sized, Data: Read + Unpin + ?Sized>(
 
 const PAX_HEADER_PATH: &str = "PaxHeaders/pax-entry";
 const PAX_PAYLOAD_PATH: &str = "pax-entry";
+// libarchive uses these special `linkname` values (in the USTAR header)
+// when adding a `linkpath` PAX extension.
+// Technically the value of the `linkname` is not important, since a PAX-compliant
+// reader should ignore it when the `linkpath` extension is present.
+const PAX_HARD_LINK_FALLBACK: &[u8] = b"././@LongHardLink";
+const PAX_SYM_LINK_FALLBACK: &[u8] = b"././@LongSymLink";
 
 struct PaxExtension {
     key: &'static [u8],
@@ -611,7 +675,14 @@ fn prepare_header_link(
     header.as_old_mut().linkname.fill(0);
     if header.set_link_name(link_name).is_err() {
         let data = link_name2pax_bytes(link_name)?;
-        header.as_old_mut().linkname.fill(0);
+        let fallback = if header.entry_type().is_hard_link() {
+            PAX_HARD_LINK_FALLBACK
+        } else {
+            PAX_SYM_LINK_FALLBACK
+        };
+        let linkname = &mut header.as_old_mut().linkname;
+        linkname.fill(0);
+        linkname[..fallback.len()].copy_from_slice(fallback);
         push_pax_extension(pax_extensions, b"linkpath", data);
     }
     Ok(())

--- a/src/entry_type.rs
+++ b/src/entry_type.rs
@@ -39,6 +39,22 @@ pub enum EntryType {
 }
 
 impl EntryType {
+    pub(crate) fn is_ustar_or_pax_writer(self) -> bool {
+        matches!(
+            self,
+            EntryType::Regular
+                | EntryType::Link
+                | EntryType::Symlink
+                | EntryType::Char
+                | EntryType::Block
+                | EntryType::Directory
+                | EntryType::Fifo
+                | EntryType::Continuous
+                | EntryType::XGlobalHeader
+                | EntryType::XHeader
+        )
+    }
+
     /// Creates a new entry type from a raw byte.
     ///
     /// Note that the other named constructors of entry type may be more
@@ -177,12 +193,12 @@ impl EntryType {
         self == EntryType::GNULongLink
     }
 
-    /// Returns whether this type represents a GNU long name header.
+    /// Returns whether this type represents a PAX global extension header.
     pub fn is_pax_global_extensions(self) -> bool {
         self == EntryType::XGlobalHeader
     }
 
-    /// Returns whether this type represents a GNU long link header.
+    /// Returns whether this type represents a PAX local extension header.
     pub fn is_pax_local_extensions(self) -> bool {
         self == EntryType::XHeader
     }

--- a/src/entry_type.rs
+++ b/src/entry_type.rs
@@ -39,22 +39,6 @@ pub enum EntryType {
 }
 
 impl EntryType {
-    pub(crate) fn is_ustar_or_pax_writer(self) -> bool {
-        matches!(
-            self,
-            EntryType::Regular
-                | EntryType::Link
-                | EntryType::Symlink
-                | EntryType::Char
-                | EntryType::Block
-                | EntryType::Directory
-                | EntryType::Fifo
-                | EntryType::Continuous
-                | EntryType::XGlobalHeader
-                | EntryType::XHeader
-        )
-    }
-
     /// Creates a new entry type from a raw byte.
     ///
     /// Note that the other named constructors of entry type may be more

--- a/src/header.rs
+++ b/src/header.rs
@@ -1348,8 +1348,7 @@ fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
 fn copy_path_into_inner(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
     let mut emitted = false;
     let mut needs_slash = false;
-    let mut iter = path.components();
-    while let Some(component) = iter.next() {
+    for component in path.components() {
         let bytes = path2bytes(Path::new(component.as_os_str()))?;
         match (component, is_link_name) {
             (Component::Prefix(..), false) | (Component::RootDir, false) => {

--- a/src/header.rs
+++ b/src/header.rs
@@ -10,12 +10,12 @@ use std::{
     iter,
     iter::{once, repeat},
     mem,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     str,
 };
 use tokio::io;
 
-use crate::{other, EntryType, LinkTarget, Name};
+use crate::{other, EntryType};
 
 /// A deterministic, arbitrary, non-zero timestamp that use used as `mtime`
 /// of headers when [`HeaderMode::Deterministic`] is used.
@@ -137,13 +137,31 @@ pub struct GnuSparseHeader {
 /// the next entry will be one of these headers.
 #[repr(C)]
 #[allow(missing_docs)]
-pub(crate) struct GnuExtSparseHeader {
+pub struct GnuExtSparseHeader {
     pub sparse: [GnuSparseHeader; 21],
     pub isextended: [u8; 1],
     pub padding: [u8; 7],
 }
 
 impl Header {
+    /// Creates a new blank GNU header.
+    ///
+    /// The GNU style header is the default for this library and allows various
+    /// extensions such as long path names, long link names, and setting the
+    /// atime/ctime metadata attributes of files.
+    pub fn new_gnu() -> Header {
+        let mut header = Header {
+            bytes: [0; BLOCK_SIZE as usize],
+        };
+        unsafe {
+            let gnu = cast_mut::<_, GnuHeader>(&mut header);
+            gnu.magic = *b"ustar ";
+            gnu.version = *b" \0";
+        }
+        header.set_mtime(0);
+        header
+    }
+
     /// Creates a new blank UStar header.
     ///
     /// The UStar style header is an extension of the original archive header
@@ -151,20 +169,26 @@ impl Header {
     /// too long) path name.
     ///
     /// UStar is also the basis used for pax archives.
-    pub(crate) fn new_ustar() -> Header {
+    pub fn new_ustar() -> Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
         unsafe {
-            let ustar = cast_mut::<_, UstarHeader>(&mut header);
-            ustar.magic = *b"ustar\0";
-            ustar.version = *b"00";
+            let gnu = cast_mut::<_, UstarHeader>(&mut header);
+            gnu.magic = *b"ustar\0";
+            gnu.version = *b"00";
         }
         header.set_mtime(0);
         header
     }
 
-    pub(crate) fn new_old() -> Header {
+    /// Creates a new blank old header.
+    ///
+    /// This header format is the original archive header format which all other
+    /// versions are compatible with (e.g. they are a superset). This header
+    /// format limits the path name limit and isn't able to contain extra
+    /// metadata like atime/ctime.
+    pub fn new_old() -> Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
@@ -190,7 +214,8 @@ impl Header {
         unsafe { cast(self) }
     }
 
-    pub(crate) fn as_old_mut(&mut self) -> &mut OldHeader {
+    /// Same as `as_old`, but the mutable version.
+    pub fn as_old_mut(&mut self) -> &mut OldHeader {
         unsafe { cast_mut(self) }
     }
 
@@ -211,7 +236,8 @@ impl Header {
         }
     }
 
-    pub(crate) fn as_ustar_mut(&mut self) -> Option<&mut UstarHeader> {
+    /// Same as `as_ustar_mut`, but the mutable version.
+    pub fn as_ustar_mut(&mut self) -> Option<&mut UstarHeader> {
         if self.is_ustar() {
             Some(unsafe { cast_mut(self) })
         } else {
@@ -236,6 +262,15 @@ impl Header {
         }
     }
 
+    /// Same as `as_gnu`, but the mutable version.
+    pub fn as_gnu_mut(&mut self) -> Option<&mut GnuHeader> {
+        if self.is_gnu() {
+            Some(unsafe { cast_mut(self) })
+        } else {
+            None
+        }
+    }
+
     /// Treats the given byte slice as a header.
     ///
     /// Panics if the length of the passed slice is not equal to 512.
@@ -250,7 +285,8 @@ impl Header {
         &self.bytes
     }
 
-    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
+    /// Returns a view into this header as a byte array.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
         &mut self.bytes
     }
 
@@ -260,9 +296,13 @@ impl Header {
     /// This is useful for initializing a `Header` from the OS's metadata from a
     /// file. By default, this will use `HeaderMode::Complete` to include all
     /// metadata.
+    pub fn set_metadata(&mut self, meta: &Metadata) {
+        self.fill_from(meta, HeaderMode::Complete);
+    }
+
     /// Sets only the metadata relevant to the given HeaderMode in this header
     /// from the metadata argument provided.
-    pub(crate) fn set_metadata_in_mode(&mut self, meta: &Metadata, mode: HeaderMode) {
+    pub fn set_metadata_in_mode(&mut self, meta: &Metadata, mode: HeaderMode) {
         self.fill_from(meta, mode);
     }
 
@@ -297,7 +337,7 @@ impl Header {
     }
 
     /// Encodes the `size` argument into the size field of this header.
-    pub(crate) fn set_size(&mut self, size: u64) {
+    pub fn set_size(&mut self, size: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().size, size);
     }
 
@@ -333,23 +373,40 @@ impl Header {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    /// Sets the path name for this header from a validated archive member name.
+    /// Sets the path name for this header.
     ///
-    /// This bare-header setter accepts only ASCII names directly representable
-    /// in USTAR. Use [`crate::Builder`] named methods when a valid name needs a
-    /// PAX `path` extension, such as a non-ASCII or overlong name.
+    /// This function will set the pathname listed in this header, encoding it
+    /// in the appropriate format. May fail if the path is too long or if the
+    /// path specified is not Unicode and this is a Windows platform. Will
+    /// strip out any "." path component, which signifies the current directory.
     ///
-    pub(crate) fn set_path(&mut self, name: &Name) -> io::Result<()> {
-        if !name.as_str().is_ascii() {
-            return Err(pax_required("path"));
-        }
+    /// Note: This function does not support names over 100 bytes, or paths
+    /// over 255 bytes, even for formats that support longer names. Instead,
+    /// use `Builder` methods to insert a long-name extension at the same time
+    /// as the file content.
+    pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+        self.set_path_inner(p.as_ref(), false)
+    }
+
+    fn set_path_inner(
+        &mut self,
+        path: &Path,
+        is_truncated_gnu_long_path: bool,
+    ) -> std::io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
-            return ustar
-                .set_path(name)
-                .then_some(())
-                .ok_or_else(|| pax_required("path"));
+            return ustar.set_path(path);
         }
-        Err(other("cannot set path on a non-USTAR header"))
+        if is_truncated_gnu_long_path {
+            copy_path_into_gnu_long(&mut self.as_old_mut().name, path, false)
+        } else {
+            copy_path_into(&mut self.as_old_mut().name, path, false)
+        }
+        .map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when setting path for {}", err, self.path_lossy()),
+            )
+        })
     }
 
     /// Returns the link name stored in this header, if any is found.
@@ -383,48 +440,23 @@ impl Header {
         }
     }
 
-    /// Sets a hard-link destination for this header.
+    /// Sets the link name for this header.
     ///
-    /// This bare-header setter accepts only ASCII [`Name`] values fitting in
-    /// the USTAR `linkname` field. Use [`crate::Builder::append_hard_link`] for
-    /// a value requiring a PAX `linkpath` extension.
-    pub(crate) fn set_hard_link_name(&mut self, name: &Name) -> io::Result<()> {
-        if !name.as_str().is_ascii() {
-            return Err(pax_required("linkpath"));
-        }
-        if self.as_ustar().is_none() {
-            return Err(other("cannot set link name on a non-USTAR header"));
-        }
-        self.set_link_name_bytes(name.as_bytes())
-            .then_some(())
-            .ok_or_else(|| pax_required("linkpath"))
+    /// This function will set the linkname listed in this header, encoding it
+    /// in the appropriate format. May fail if the link name is too long or if
+    /// the path specified is not Unicode and this is a Windows platform. Will
+    /// strip out any "." path component, which signifies the current directory.
+    pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+        self._set_link_name(p.as_ref())
     }
 
-    /// Sets a symbolic-link target for this header.
-    ///
-    /// This bare-header setter accepts only ASCII [`LinkTarget`] values fitting
-    /// in the USTAR `linkname` field. Use [`crate::Builder::append_symlink`]
-    /// for a value requiring a PAX `linkpath` extension.
-    pub(crate) fn set_symlink_target(&mut self, target: &LinkTarget) -> io::Result<()> {
-        if !target.as_str().is_ascii() {
-            return Err(pax_required("linkpath"));
-        }
-        if self.as_ustar().is_none() {
-            return Err(other("cannot set link name on a non-USTAR header"));
-        }
-        self.set_link_name_bytes(target.as_bytes())
-            .then_some(())
-            .ok_or_else(|| pax_required("linkpath"))
-    }
-
-    fn set_link_name_bytes(&mut self, value: &[u8]) -> bool {
-        let linkname = &mut self.as_old_mut().linkname;
-        if value.len() > linkname.len() {
-            return false;
-        }
-        linkname.fill(0);
-        linkname[..value.len()].copy_from_slice(value);
-        true
+    fn _set_link_name(&mut self, path: &Path) -> io::Result<()> {
+        copy_path_into(&mut self.as_old_mut().linkname, path, true).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when setting link name for {}", err, self.path_lossy()),
+            )
+        })
     }
 
     /// Returns the mode bits for this file
@@ -442,7 +474,7 @@ impl Header {
     }
 
     /// Encodes the `mode` provided into this header.
-    pub(crate) fn set_mode(&mut self, mode: u32) {
+    pub fn set_mode(&mut self, mode: u32) {
         octal_into(&mut self.as_old_mut().mode, mode);
     }
 
@@ -459,7 +491,7 @@ impl Header {
     }
 
     /// Encodes the `uid` provided into this header.
-    pub(crate) fn set_uid(&mut self, uid: u64) {
+    pub fn set_uid(&mut self, uid: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().uid, uid);
     }
 
@@ -474,7 +506,7 @@ impl Header {
     }
 
     /// Encodes the `gid` provided into this header.
-    pub(crate) fn set_gid(&mut self, gid: u64) {
+    pub fn set_gid(&mut self, gid: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().gid, gid);
     }
 
@@ -492,7 +524,7 @@ impl Header {
     ///
     /// Note that this time is typically a number of seconds passed since
     /// January 1, 1970.
-    pub(crate) fn set_mtime(&mut self, mtime: u64) {
+    pub fn set_mtime(&mut self, mtime: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().mtime, mtime);
     }
 
@@ -524,6 +556,21 @@ impl Header {
         }
     }
 
+    /// Sets the username inside this header.
+    ///
+    /// This function will return an error if this header format cannot encode a
+    /// user name or the name is too long.
+    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
+        if let Some(ustar) = self.as_ustar_mut() {
+            return ustar.set_username(name);
+        }
+        if let Some(gnu) = self.as_gnu_mut() {
+            gnu.set_username(name)
+        } else {
+            Err(other("not a ustar or gnu archive, cannot set username"))
+        }
+    }
+
     /// Return the group name of the owner of this file.
     ///
     /// A return value of `Ok(Some(..))` indicates that the group name was
@@ -552,6 +599,21 @@ impl Header {
         }
     }
 
+    /// Sets the group name inside this header.
+    ///
+    /// This function will return an error if this header format cannot encode a
+    /// group name or the name is too long.
+    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
+        if let Some(ustar) = self.as_ustar_mut() {
+            return ustar.set_groupname(name);
+        }
+        if let Some(gnu) = self.as_gnu_mut() {
+            gnu.set_groupname(name)
+        } else {
+            Err(other("not a ustar or gnu archive, cannot set groupname"))
+        }
+    }
+
     /// Returns the device major number, if present.
     ///
     /// This field may not be present in all archives, and it may not be
@@ -573,12 +635,15 @@ impl Header {
     ///
     /// This function will return an error if this header format cannot encode a
     /// major device number.
-    pub(crate) fn set_device_major(&mut self, major: u32) -> io::Result<()> {
+    pub fn set_device_major(&mut self, major: u32) -> io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_major(major);
             Ok(())
+        } else if let Some(gnu) = self.as_gnu_mut() {
+            gnu.set_device_major(major);
+            Ok(())
         } else {
-            Err(other("cannot set dev_major on a non-USTAR header"))
+            Err(other("not a ustar or gnu archive, cannot set dev_major"))
         }
     }
 
@@ -603,12 +668,15 @@ impl Header {
     ///
     /// This function will return an error if this header format cannot encode a
     /// minor device number.
-    pub(crate) fn set_device_minor(&mut self, minor: u32) -> io::Result<()> {
+    pub fn set_device_minor(&mut self, minor: u32) -> io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_minor(minor);
             Ok(())
+        } else if let Some(gnu) = self.as_gnu_mut() {
+            gnu.set_device_minor(minor);
+            Ok(())
         } else {
-            Err(other("cannot set dev_minor on a non-USTAR header"))
+            Err(other("not a ustar or gnu archive, cannot set dev_minor"))
         }
     }
 
@@ -618,21 +686,7 @@ impl Header {
     }
 
     /// Sets the type of file that will be described by this header.
-    ///
-    /// GNU extension entry types cannot be written directly. The builder uses
-    /// PAX extension entries when a USTAR header cannot represent an entry.
-    pub(crate) fn set_entry_type(&mut self, ty: EntryType) -> io::Result<()> {
-        if self.as_ustar().is_none() {
-            return Err(other("cannot set entry type on a non-USTAR header"));
-        }
-        if !ty.is_ustar_or_pax_writer() {
-            return Err(other("cannot set a GNU or unknown entry type"));
-        }
-        self.set_entry_type_unchecked(ty);
-        Ok(())
-    }
-
-    pub(crate) fn set_entry_type_unchecked(&mut self, ty: EntryType) {
+    pub fn set_entry_type(&mut self, ty: EntryType) {
         self.as_old_mut().linkflag = [ty.as_byte()];
     }
 
@@ -652,7 +706,7 @@ impl Header {
 
     /// Sets the checksum field of this header based on the current fields in
     /// this header.
-    pub(crate) fn set_cksum(&mut self) {
+    pub fn set_cksum(&mut self) {
         let cksum = self.calculate_cksum();
         octal_into(&mut self.as_old_mut().cksum, cksum);
     }
@@ -681,6 +735,10 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_major(0);
             ustar.set_device_minor(0);
+        }
+        if let Some(gnu) = self.as_gnu_mut() {
+            gnu.set_device_major(0);
+            gnu.set_device_minor(0);
         }
     }
 
@@ -729,7 +787,7 @@ impl Header {
         // [1]: https://github.com/alexcrichton/tar-rs/issues/70
 
         // TODO: need to bind more file types
-        self.set_entry_type_unchecked(entry_type(meta.mode()));
+        self.set_entry_type(entry_type(meta.mode()));
 
         fn entry_type(mode: u32) -> EntryType {
             match mode as libc::mode_t & libc::S_IFMT {
@@ -779,7 +837,7 @@ impl Header {
         }
 
         let ft = meta.file_type();
-        self.set_entry_type_unchecked(if ft.is_dir() {
+        self.set_entry_type(if ft.is_dir() {
             EntryType::dir()
         } else if ft.is_file() {
             EntryType::file()
@@ -877,6 +935,11 @@ impl OldHeader {
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
     }
+
+    /// Views this as a normal `Header`
+    pub fn as_header_mut(&mut self) -> &mut Header {
+        unsafe { cast_mut(self) }
+    }
 }
 
 impl fmt::Debug for OldHeader {
@@ -909,29 +972,62 @@ impl UstarHeader {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    fn set_path(&mut self, name: &Name) -> bool {
-        let bytes = name.as_bytes();
-        let (prefix, suffix) = if bytes.len() <= self.name.len() {
-            (&[][..], bytes)
-        } else {
-            let Some(split) = bytes.iter().enumerate().rev().find_map(|(index, byte)| {
-                let suffix = &bytes[index + 1..];
-                (*byte == b'/'
-                    && index <= self.prefix.len()
-                    && !suffix.is_empty()
-                    && suffix.len() <= self.name.len())
-                .then_some(index)
-            }) else {
-                return false;
-            };
-            (&bytes[..split], &bytes[split + 1..])
-        };
+    /// See `Header::set_path`
+    pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+        self._set_path(p.as_ref())
+    }
 
-        self.name.fill(0);
-        self.prefix.fill(0);
-        self.name[..suffix.len()].copy_from_slice(suffix);
-        self.prefix[..prefix.len()].copy_from_slice(prefix);
-        true
+    fn _set_path(&mut self, path: &Path) -> io::Result<()> {
+        // This can probably be optimized quite a bit more, but for now just do
+        // something that's relatively easy and readable.
+        //
+        // First up, if the path fits within `self.name` then we just shove it
+        // in there. If not then we try to split it between some existing path
+        // components where it can fit in name/prefix. To do that we peel off
+        // enough until the path fits in `prefix`, then we try to put both
+        // halves into their destination.
+        let bytes = path2bytes(path)?;
+        let (maxnamelen, maxprefixlen) = (self.name.len(), self.prefix.len());
+        if bytes.len() <= maxnamelen {
+            copy_path_into(&mut self.name, path, false).map_err(|err| {
+                io::Error::new(
+                    err.kind(),
+                    format!("{} when setting path for {}", err, self.path_lossy()),
+                )
+            })?;
+        } else {
+            let mut prefix = path;
+            let mut prefixlen;
+            loop {
+                match prefix.parent() {
+                    Some(parent) => prefix = parent,
+                    None => {
+                        return Err(other(&format!(
+                            "path cannot be split to be inserted into archive: {}",
+                            path.display()
+                        )));
+                    }
+                }
+                prefixlen = path2bytes(prefix)?.len();
+                if prefixlen <= maxprefixlen {
+                    break;
+                }
+            }
+            copy_path_into(&mut self.prefix, prefix, false).map_err(|err| {
+                io::Error::new(
+                    err.kind(),
+                    format!("{} when setting path for {}", err, self.path_lossy()),
+                )
+            })?;
+            let path = bytes2path(Cow::Borrowed(&bytes[prefixlen + 1..]))?;
+            copy_path_into(&mut self.name, &path, false).map_err(|err| {
+                io::Error::new(
+                    err.kind(),
+                    format!("{} when setting path for {}", err, self.path_lossy()),
+                )
+            })?;
+        }
+        Ok(())
     }
 
     /// See `Header::username_bytes`
@@ -939,9 +1035,29 @@ impl UstarHeader {
         truncate(&self.uname)
     }
 
+    /// See `Header::set_username`
+    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
+        copy_into(&mut self.uname, name.as_bytes()).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when setting username for {}", err, self.path_lossy()),
+            )
+        })
+    }
+
     /// See `Header::groupname_bytes`
     pub fn groupname_bytes(&self) -> &[u8] {
         truncate(&self.gname)
+    }
+
+    /// See `Header::set_groupname`
+    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
+        copy_into(&mut self.gname, name.as_bytes()).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when setting groupname for {}", err, self.path_lossy()),
+            )
+        })
     }
 
     /// See `Header::device_major`
@@ -960,7 +1076,8 @@ impl UstarHeader {
             })
     }
 
-    fn set_device_major(&mut self, major: u32) {
+    /// See `Header::set_device_major`
+    pub fn set_device_major(&mut self, major: u32) {
         octal_into(&mut self.dev_major, major);
     }
 
@@ -980,13 +1097,19 @@ impl UstarHeader {
             })
     }
 
-    fn set_device_minor(&mut self, minor: u32) {
+    /// See `Header::set_device_minor`
+    pub fn set_device_minor(&mut self, minor: u32) {
         octal_into(&mut self.dev_minor, minor);
     }
 
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
+    }
+
+    /// Views this as a normal `Header`
+    pub fn as_header_mut(&mut self) -> &mut Header {
+        unsafe { cast_mut(self) }
     }
 }
 
@@ -1013,9 +1136,37 @@ impl GnuHeader {
         )
     }
 
+    /// See `Header::set_username`
+    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
+        copy_into(&mut self.uname, name.as_bytes()).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "{} when setting username for {}",
+                    err,
+                    self.fullname_lossy()
+                ),
+            )
+        })
+    }
+
     /// See `Header::groupname_bytes`
     pub fn groupname_bytes(&self) -> &[u8] {
         truncate(&self.gname)
+    }
+
+    /// See `Header::set_groupname`
+    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
+        copy_into(&mut self.gname, name.as_bytes()).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "{} when setting groupname for {}",
+                    err,
+                    self.fullname_lossy()
+                ),
+            )
+        })
     }
 
     /// See `Header::device_major`
@@ -1034,6 +1185,11 @@ impl GnuHeader {
             })
     }
 
+    /// See `Header::set_device_major`
+    pub fn set_device_major(&mut self, major: u32) {
+        octal_into(&mut self.dev_major, major);
+    }
+
     /// See `Header::device_minor`
     pub fn device_minor(&self) -> io::Result<u32> {
         octal_from(&self.dev_minor)
@@ -1050,6 +1206,11 @@ impl GnuHeader {
             })
     }
 
+    /// See `Header::set_device_minor`
+    pub fn set_device_minor(&mut self, minor: u32) {
+        octal_into(&mut self.dev_minor, minor);
+    }
+
     /// Returns the last modification time in Unix time format
     pub fn atime(&self) -> io::Result<u64> {
         num_field_wrapper_from(&self.atime).map_err(|err| {
@@ -1060,6 +1221,14 @@ impl GnuHeader {
         })
     }
 
+    /// Encodes the `atime` provided into this header.
+    ///
+    /// Note that this time is typically a number of seconds passed since
+    /// January 1, 1970.
+    pub fn set_atime(&mut self, atime: u64) {
+        num_field_wrapper_into(&mut self.atime, atime);
+    }
+
     /// Returns the last modification time in Unix time format
     pub fn ctime(&self) -> io::Result<u64> {
         num_field_wrapper_from(&self.ctime).map_err(|err| {
@@ -1068,6 +1237,14 @@ impl GnuHeader {
                 format!("{} when getting ctime for {}", err, self.fullname_lossy()),
             )
         })
+    }
+
+    /// Encodes the `ctime` provided into this header.
+    ///
+    /// Note that this time is typically a number of seconds passed since
+    /// January 1, 1970.
+    pub fn set_ctime(&mut self, ctime: u64) {
+        num_field_wrapper_into(&mut self.ctime, ctime);
     }
 
     /// Returns the "real size" of the file this header represents.
@@ -1099,6 +1276,11 @@ impl GnuHeader {
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
+    }
+
+    /// Views this as a normal `Header`
+    pub fn as_header_mut(&mut self) -> &mut Header {
+        unsafe { cast_mut(self) }
     }
 }
 
@@ -1177,18 +1359,40 @@ impl fmt::Debug for GnuSparseHeader {
 }
 
 impl GnuExtSparseHeader {
-    pub(crate) fn new() -> GnuExtSparseHeader {
+    /// Crates a new zero'd out sparse header entry.
+    pub fn new() -> GnuExtSparseHeader {
         unsafe { mem::zeroed() }
     }
 
-    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
+    /// Returns a view into this header as a byte array.
+    pub fn as_bytes(&self) -> &[u8; BLOCK_SIZE as usize] {
+        debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
+        unsafe { &*(self as *const GnuExtSparseHeader as *const [u8; BLOCK_SIZE as usize]) }
+    }
+
+    /// Returns a view into this header as a byte array.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
         debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
         unsafe { &mut *(self as *mut GnuExtSparseHeader as *mut [u8; BLOCK_SIZE as usize]) }
+    }
+
+    /// Returns a slice of the underlying sparse headers.
+    ///
+    /// Some headers may represent empty chunks of both the offset and numbytes
+    /// fields are 0.
+    pub fn sparse(&self) -> &[GnuSparseHeader; 21] {
+        &self.sparse
     }
 
     /// Indicates if another sparse header should be following this one.
     pub fn is_extended(&self) -> bool {
         self.isextended[0] == 1
+    }
+}
+
+impl Default for GnuExtSparseHeader {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1276,10 +1480,147 @@ fn truncate(slice: &[u8]) -> &[u8] {
     }
 }
 
-fn pax_required(field: &str) -> io::Error {
-    other(&format!(
-        "{field} requires a PAX extension; use Builder named methods when writing this entry"
-    ))
+/// Copies `bytes` into the `slot` provided, returning an error if the `bytes`
+/// array is too long or if it contains any nul bytes.
+fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
+    if bytes.len() > slot.len() {
+        Err(other("provided value is too long"))
+    } else if bytes.contains(&0) {
+        Err(other("provided value contains a nul byte"))
+    } else {
+        for (slot, val) in slot.iter_mut().zip(bytes.iter().chain(Some(&0))) {
+            *slot = *val;
+        }
+        Ok(())
+    }
+}
+
+fn copy_path_into_inner(
+    mut slot: &mut [u8],
+    path: &Path,
+    is_link_name: bool,
+    is_truncated_gnu_long_path: bool,
+) -> io::Result<()> {
+    let mut emitted = false;
+    let mut needs_slash = false;
+    let mut iter = path.components().peekable();
+    while let Some(component) = iter.next() {
+        let bytes = path2bytes(Path::new(component.as_os_str()))?;
+        match (component, is_link_name) {
+            (Component::Prefix(..), false) | (Component::RootDir, false) => {
+                return Err(other("paths in archives must be relative"));
+            }
+            (Component::ParentDir, false) => {
+                // If it's last component of a gnu long path we know that there might be more
+                // to the component than .. (the rest is stored elsewhere)
+                // Otherwise it's a clear error
+                if !is_truncated_gnu_long_path || iter.peek().is_some() {
+                    return Err(other("paths in archives must not have `..`"));
+                }
+            }
+            // Allow "./" as the path
+            (Component::CurDir, false) if path.components().count() == 1 => {}
+            (Component::CurDir, false) => continue,
+            (Component::Normal(_), _) | (_, true) => {}
+        };
+        if needs_slash {
+            copy(&mut slot, b"/")?;
+        }
+        if bytes.contains(&b'/') {
+            if let Component::Normal(..) = component {
+                return Err(other("path component in archive cannot contain `/`"));
+            }
+        }
+        copy(&mut slot, &bytes)?;
+        if &*bytes != b"/" {
+            needs_slash = true;
+        }
+        emitted = true;
+    }
+    if !emitted {
+        return Err(other("paths in archives must have at least one component"));
+    }
+    if ends_with_slash(path) {
+        copy(&mut slot, b"/")?;
+    }
+    return Ok(());
+
+    fn copy(slot: &mut &mut [u8], bytes: &[u8]) -> io::Result<()> {
+        copy_into(slot, bytes)?;
+        let tmp = std::mem::take(slot);
+        *slot = &mut tmp[bytes.len()..];
+        Ok(())
+    }
+}
+
+/// Copies `path` into the `slot` provided
+///
+/// Returns an error if:
+///
+/// * the path is too long to fit
+/// * a nul byte was found
+/// * an invalid path component is encountered (e.g. a root path or parent dir)
+/// * the path itself is empty
+fn copy_path_into(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+    copy_path_into_inner(slot, path, is_link_name, false)
+}
+
+/// Copies `path` into the `slot` provided
+///
+/// Returns an error if:
+///
+/// * the path is too long to fit
+/// * a nul byte was found
+/// * an invalid path component is encountered (e.g. a root path or parent dir)
+/// * the path itself is empty
+///
+/// This is less restrictive version meant to be used for truncated GNU paths.
+fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
+    copy_path_into_inner(slot, path, is_link_name, true)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn ends_with_slash(p: &Path) -> bool {
+    p.to_string_lossy().ends_with('/')
+}
+
+#[cfg(windows)]
+fn ends_with_slash(p: &Path) -> bool {
+    let last = p.as_os_str().encode_wide().last();
+    last == Some(b'/' as u16) || last == Some(b'\\' as u16)
+}
+
+#[cfg(unix)]
+fn ends_with_slash(p: &Path) -> bool {
+    p.as_os_str().as_bytes().ends_with(b"/")
+}
+
+#[cfg(any(windows, target_arch = "wasm32"))]
+pub fn path2bytes(p: &Path) -> io::Result<Cow<'_, [u8]>> {
+    p.as_os_str()
+        .to_str()
+        .map(|s| s.as_bytes())
+        .ok_or_else(|| other(&format!("path {} was not valid Unicode", p.display())))
+        .map(|bytes| {
+            if bytes.contains(&b'\\') {
+                // Normalize to Unix-style path separators
+                let mut bytes = bytes.to_owned();
+                for b in &mut bytes {
+                    if *b == b'\\' {
+                        *b = b'/';
+                    }
+                }
+                Cow::Owned(bytes)
+            } else {
+                Cow::Borrowed(bytes)
+            }
+        })
+}
+
+#[cfg(unix)]
+/// On unix this will never fail
+pub fn path2bytes(p: &Path) -> io::Result<Cow<'_, [u8]>> {
+    Ok(Cow::Borrowed(p.as_os_str().as_bytes()))
 }
 
 #[cfg(windows)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -137,31 +137,13 @@ pub struct GnuSparseHeader {
 /// the next entry will be one of these headers.
 #[repr(C)]
 #[allow(missing_docs)]
-pub struct GnuExtSparseHeader {
+pub(crate) struct GnuExtSparseHeader {
     pub sparse: [GnuSparseHeader; 21],
     pub isextended: [u8; 1],
     pub padding: [u8; 7],
 }
 
 impl Header {
-    /// Creates a new blank GNU header.
-    ///
-    /// The GNU style header is the default for this library and allows various
-    /// extensions such as long path names, long link names, and setting the
-    /// atime/ctime metadata attributes of files.
-    pub fn new_gnu() -> Header {
-        let mut header = Header {
-            bytes: [0; BLOCK_SIZE as usize],
-        };
-        unsafe {
-            let gnu = cast_mut::<_, GnuHeader>(&mut header);
-            gnu.magic = *b"ustar ";
-            gnu.version = *b" \0";
-        }
-        header.set_mtime(0);
-        header
-    }
-
     /// Creates a new blank UStar header.
     ///
     /// The UStar style header is an extension of the original archive header
@@ -174,21 +156,15 @@ impl Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
         unsafe {
-            let gnu = cast_mut::<_, UstarHeader>(&mut header);
-            gnu.magic = *b"ustar\0";
-            gnu.version = *b"00";
+            let ustar = cast_mut::<_, UstarHeader>(&mut header);
+            ustar.magic = *b"ustar\0";
+            ustar.version = *b"00";
         }
         header.set_mtime(0);
         header
     }
 
-    /// Creates a new blank old header.
-    ///
-    /// This header format is the original archive header format which all other
-    /// versions are compatible with (e.g. they are a superset). This header
-    /// format limits the path name limit and isn't able to contain extra
-    /// metadata like atime/ctime.
-    pub fn new_old() -> Header {
+    pub(crate) fn new_old() -> Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
@@ -214,8 +190,7 @@ impl Header {
         unsafe { cast(self) }
     }
 
-    /// Same as `as_old`, but the mutable version.
-    pub fn as_old_mut(&mut self) -> &mut OldHeader {
+    pub(crate) fn as_old_mut(&mut self) -> &mut OldHeader {
         unsafe { cast_mut(self) }
     }
 
@@ -236,8 +211,7 @@ impl Header {
         }
     }
 
-    /// Same as `as_ustar_mut`, but the mutable version.
-    pub fn as_ustar_mut(&mut self) -> Option<&mut UstarHeader> {
+    pub(crate) fn as_ustar_mut(&mut self) -> Option<&mut UstarHeader> {
         if self.is_ustar() {
             Some(unsafe { cast_mut(self) })
         } else {
@@ -262,15 +236,6 @@ impl Header {
         }
     }
 
-    /// Same as `as_gnu`, but the mutable version.
-    pub fn as_gnu_mut(&mut self) -> Option<&mut GnuHeader> {
-        if self.is_gnu() {
-            Some(unsafe { cast_mut(self) })
-        } else {
-            None
-        }
-    }
-
     /// Treats the given byte slice as a header.
     ///
     /// Panics if the length of the passed slice is not equal to 512.
@@ -285,8 +250,7 @@ impl Header {
         &self.bytes
     }
 
-    /// Returns a view into this header as a byte array.
-    pub fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
+    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
         &mut self.bytes
     }
 
@@ -382,41 +346,14 @@ impl Header {
     ///
     /// Note: This function does not support names over 100 bytes, or paths
     /// over 255 bytes, even for formats that support longer names. Instead,
-    /// use `Builder` methods to insert a long-name extension at the same time
-    /// as the file content.
+    /// use `Builder` methods to insert a PAX path extension at the same time as
+    /// the file content.
     pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
-        self.set_path_inner(p.as_ref(), false)
-    }
-
-    // Sets the truncated path for GNU header
-    //
-    // Same as set_path but skips some validations.
-    pub(crate) fn set_truncated_path_for_gnu_header<P: AsRef<Path>>(
-        &mut self,
-        p: P,
-    ) -> std::io::Result<()> {
-        self.set_path_inner(p.as_ref(), true)
-    }
-
-    fn set_path_inner(
-        &mut self,
-        path: &Path,
-        is_truncated_gnu_long_path: bool,
-    ) -> std::io::Result<()> {
+        let path = p.as_ref();
         if let Some(ustar) = self.as_ustar_mut() {
             return ustar.set_path(path);
         }
-        if is_truncated_gnu_long_path {
-            copy_path_into_gnu_long(&mut self.as_old_mut().name, path, false)
-        } else {
-            copy_path_into(&mut self.as_old_mut().name, path, false)
-        }
-        .map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!("{} when setting path for {}", err, self.path_lossy()),
-            )
-        })
+        Err(other("cannot set path on a non-USTAR header"))
     }
 
     /// Returns the link name stored in this header, if any is found.
@@ -457,6 +394,9 @@ impl Header {
     /// the path specified is not Unicode and this is a Windows platform. Will
     /// strip out any "." path component, which signifies the current directory.
     pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+        if self.as_ustar().is_none() {
+            return Err(other("cannot set link name on a non-USTAR header"));
+        }
         self._set_link_name(p.as_ref())
     }
 
@@ -574,11 +514,7 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             return ustar.set_username(name);
         }
-        if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_username(name)
-        } else {
-            Err(other("not a ustar or gnu archive, cannot set username"))
-        }
+        Err(other("cannot set username on a non-USTAR header"))
     }
 
     /// Return the group name of the owner of this file.
@@ -617,11 +553,7 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             return ustar.set_groupname(name);
         }
-        if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_groupname(name)
-        } else {
-            Err(other("not a ustar or gnu archive, cannot set groupname"))
-        }
+        Err(other("cannot set group name on a non-USTAR header"))
     }
 
     /// Returns the device major number, if present.
@@ -649,11 +581,8 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_major(major);
             Ok(())
-        } else if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_device_major(major);
-            Ok(())
         } else {
-            Err(other("not a ustar or gnu archive, cannot set dev_major"))
+            Err(other("cannot set dev_major on a non-USTAR header"))
         }
     }
 
@@ -682,11 +611,8 @@ impl Header {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_minor(minor);
             Ok(())
-        } else if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_device_minor(minor);
-            Ok(())
         } else {
-            Err(other("not a ustar or gnu archive, cannot set dev_minor"))
+            Err(other("cannot set dev_minor on a non-USTAR header"))
         }
     }
 
@@ -696,7 +622,21 @@ impl Header {
     }
 
     /// Sets the type of file that will be described by this header.
-    pub fn set_entry_type(&mut self, ty: EntryType) {
+    ///
+    /// GNU extension entry types cannot be written directly. The builder uses
+    /// PAX extension entries when a USTAR header cannot represent an entry.
+    pub fn set_entry_type(&mut self, ty: EntryType) -> io::Result<()> {
+        if self.as_ustar().is_none() {
+            return Err(other("cannot set entry type on a non-USTAR header"));
+        }
+        if !ty.is_ustar_or_pax_writer() {
+            return Err(other("cannot set a GNU or unknown entry type"));
+        }
+        self.set_entry_type_unchecked(ty);
+        Ok(())
+    }
+
+    pub(crate) fn set_entry_type_unchecked(&mut self, ty: EntryType) {
         self.as_old_mut().linkflag = [ty.as_byte()];
     }
 
@@ -746,10 +686,6 @@ impl Header {
             ustar.set_device_major(0);
             ustar.set_device_minor(0);
         }
-        if let Some(gnu) = self.as_gnu_mut() {
-            gnu.set_device_major(0);
-            gnu.set_device_minor(0);
-        }
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -797,7 +733,7 @@ impl Header {
         // [1]: https://github.com/alexcrichton/tar-rs/issues/70
 
         // TODO: need to bind more file types
-        self.set_entry_type(entry_type(meta.mode()));
+        self.set_entry_type_unchecked(entry_type(meta.mode()));
 
         fn entry_type(mode: u32) -> EntryType {
             match mode as libc::mode_t & libc::S_IFMT {
@@ -847,7 +783,7 @@ impl Header {
         }
 
         let ft = meta.file_type();
-        self.set_entry_type(if ft.is_dir() {
+        self.set_entry_type_unchecked(if ft.is_dir() {
             EntryType::dir()
         } else if ft.is_file() {
             EntryType::file()
@@ -945,11 +881,6 @@ impl OldHeader {
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
     }
-
-    /// Views this as a normal `Header`
-    pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
-    }
 }
 
 impl fmt::Debug for OldHeader {
@@ -982,8 +913,7 @@ impl UstarHeader {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    /// See `Header::set_path`
-    pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+    fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
         self._set_path(p.as_ref())
     }
 
@@ -1045,8 +975,7 @@ impl UstarHeader {
         truncate(&self.uname)
     }
 
-    /// See `Header::set_username`
-    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
+    fn set_username(&mut self, name: &str) -> io::Result<()> {
         copy_into(&mut self.uname, name.as_bytes()).map_err(|err| {
             io::Error::new(
                 err.kind(),
@@ -1060,8 +989,7 @@ impl UstarHeader {
         truncate(&self.gname)
     }
 
-    /// See `Header::set_groupname`
-    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
+    fn set_groupname(&mut self, name: &str) -> io::Result<()> {
         copy_into(&mut self.gname, name.as_bytes()).map_err(|err| {
             io::Error::new(
                 err.kind(),
@@ -1086,8 +1014,7 @@ impl UstarHeader {
             })
     }
 
-    /// See `Header::set_device_major`
-    pub fn set_device_major(&mut self, major: u32) {
+    fn set_device_major(&mut self, major: u32) {
         octal_into(&mut self.dev_major, major);
     }
 
@@ -1107,19 +1034,13 @@ impl UstarHeader {
             })
     }
 
-    /// See `Header::set_device_minor`
-    pub fn set_device_minor(&mut self, minor: u32) {
+    fn set_device_minor(&mut self, minor: u32) {
         octal_into(&mut self.dev_minor, minor);
     }
 
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
-    }
-
-    /// Views this as a normal `Header`
-    pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
     }
 }
 
@@ -1146,37 +1067,9 @@ impl GnuHeader {
         )
     }
 
-    /// See `Header::set_username`
-    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
-        copy_into(&mut self.uname, name.as_bytes()).map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!(
-                    "{} when setting username for {}",
-                    err,
-                    self.fullname_lossy()
-                ),
-            )
-        })
-    }
-
     /// See `Header::groupname_bytes`
     pub fn groupname_bytes(&self) -> &[u8] {
         truncate(&self.gname)
-    }
-
-    /// See `Header::set_groupname`
-    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
-        copy_into(&mut self.gname, name.as_bytes()).map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!(
-                    "{} when setting groupname for {}",
-                    err,
-                    self.fullname_lossy()
-                ),
-            )
-        })
     }
 
     /// See `Header::device_major`
@@ -1195,11 +1088,6 @@ impl GnuHeader {
             })
     }
 
-    /// See `Header::set_device_major`
-    pub fn set_device_major(&mut self, major: u32) {
-        octal_into(&mut self.dev_major, major);
-    }
-
     /// See `Header::device_minor`
     pub fn device_minor(&self) -> io::Result<u32> {
         octal_from(&self.dev_minor)
@@ -1216,11 +1104,6 @@ impl GnuHeader {
             })
     }
 
-    /// See `Header::set_device_minor`
-    pub fn set_device_minor(&mut self, minor: u32) {
-        octal_into(&mut self.dev_minor, minor);
-    }
-
     /// Returns the last modification time in Unix time format
     pub fn atime(&self) -> io::Result<u64> {
         num_field_wrapper_from(&self.atime).map_err(|err| {
@@ -1231,14 +1114,6 @@ impl GnuHeader {
         })
     }
 
-    /// Encodes the `atime` provided into this header.
-    ///
-    /// Note that this time is typically a number of seconds passed since
-    /// January 1, 1970.
-    pub fn set_atime(&mut self, atime: u64) {
-        num_field_wrapper_into(&mut self.atime, atime);
-    }
-
     /// Returns the last modification time in Unix time format
     pub fn ctime(&self) -> io::Result<u64> {
         num_field_wrapper_from(&self.ctime).map_err(|err| {
@@ -1247,14 +1122,6 @@ impl GnuHeader {
                 format!("{} when getting ctime for {}", err, self.fullname_lossy()),
             )
         })
-    }
-
-    /// Encodes the `ctime` provided into this header.
-    ///
-    /// Note that this time is typically a number of seconds passed since
-    /// January 1, 1970.
-    pub fn set_ctime(&mut self, ctime: u64) {
-        num_field_wrapper_into(&mut self.ctime, ctime);
     }
 
     /// Returns the "real size" of the file this header represents.
@@ -1286,11 +1153,6 @@ impl GnuHeader {
     /// Views this as a normal `Header`
     pub fn as_header(&self) -> &Header {
         unsafe { cast(self) }
-    }
-
-    /// Views this as a normal `Header`
-    pub fn as_header_mut(&mut self) -> &mut Header {
-        unsafe { cast_mut(self) }
     }
 }
 
@@ -1369,40 +1231,18 @@ impl fmt::Debug for GnuSparseHeader {
 }
 
 impl GnuExtSparseHeader {
-    /// Crates a new zero'd out sparse header entry.
-    pub fn new() -> GnuExtSparseHeader {
+    pub(crate) fn new() -> GnuExtSparseHeader {
         unsafe { mem::zeroed() }
     }
 
-    /// Returns a view into this header as a byte array.
-    pub fn as_bytes(&self) -> &[u8; BLOCK_SIZE as usize] {
-        debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
-        unsafe { &*(self as *const GnuExtSparseHeader as *const [u8; BLOCK_SIZE as usize]) }
-    }
-
-    /// Returns a view into this header as a byte array.
-    pub fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
+    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; BLOCK_SIZE as usize] {
         debug_assert_eq!(mem::size_of_val(self), BLOCK_SIZE as usize);
         unsafe { &mut *(self as *mut GnuExtSparseHeader as *mut [u8; BLOCK_SIZE as usize]) }
-    }
-
-    /// Returns a slice of the underlying sparse headers.
-    ///
-    /// Some headers may represent empty chunks of both the offset and numbytes
-    /// fields are 0.
-    pub fn sparse(&self) -> &[GnuSparseHeader; 21] {
-        &self.sparse
     }
 
     /// Indicates if another sparse header should be following this one.
     pub fn is_extended(&self) -> bool {
         self.isextended[0] == 1
-    }
-}
-
-impl Default for GnuExtSparseHeader {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -1505,15 +1345,10 @@ fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
     }
 }
 
-fn copy_path_into_inner(
-    mut slot: &mut [u8],
-    path: &Path,
-    is_link_name: bool,
-    is_truncated_gnu_long_path: bool,
-) -> io::Result<()> {
+fn copy_path_into_inner(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
     let mut emitted = false;
     let mut needs_slash = false;
-    let mut iter = path.components().peekable();
+    let mut iter = path.components();
     while let Some(component) = iter.next() {
         let bytes = path2bytes(Path::new(component.as_os_str()))?;
         match (component, is_link_name) {
@@ -1521,12 +1356,7 @@ fn copy_path_into_inner(
                 return Err(other("paths in archives must be relative"));
             }
             (Component::ParentDir, false) => {
-                // If it's last component of a gnu long path we know that there might be more
-                // to the component than .. (the rest is stored elsewhere)
-                // Otherwise it's a clear error
-                if !is_truncated_gnu_long_path || iter.peek().is_some() {
-                    return Err(other("paths in archives must not have `..`"));
-                }
+                return Err(other("paths in archives must not have `..`"));
             }
             // Allow "./" as the path
             (Component::CurDir, false) if path.components().count() == 1 => {}
@@ -1572,21 +1402,26 @@ fn copy_path_into_inner(
 /// * an invalid path component is encountered (e.g. a root path or parent dir)
 /// * the path itself is empty
 fn copy_path_into(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
-    copy_path_into_inner(slot, path, is_link_name, false)
+    copy_path_into_inner(slot, path, is_link_name)
 }
 
-/// Copies `path` into the `slot` provided
-///
-/// Returns an error if:
-///
-/// * the path is too long to fit
-/// * a nul byte was found
-/// * an invalid path component is encountered (e.g. a root path or parent dir)
-/// * the path itself is empty
-///
-/// This is less restrictive version meant to be used for truncated GNU paths.
-fn copy_path_into_gnu_long(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
-    copy_path_into_inner(slot, path, is_link_name, true)
+pub(crate) fn path2pax_bytes(path: &Path) -> io::Result<Vec<u8>> {
+    path2pax_bytes_inner(path, false)
+}
+
+pub(crate) fn link_name2pax_bytes(path: &Path) -> io::Result<Vec<u8>> {
+    path2pax_bytes_inner(path, true)
+}
+
+fn path2pax_bytes_inner(path: &Path, is_link_name: bool) -> io::Result<Vec<u8>> {
+    let capacity = path2bytes(path)?
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| other("path is too long"))?;
+    let mut bytes = vec![0; capacity];
+    copy_path_into(&mut bytes, path, is_link_name)?;
+    bytes.truncate(truncate(&bytes).len());
+    Ok(bytes)
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/src/header.rs
+++ b/src/header.rs
@@ -10,12 +10,12 @@ use std::{
     iter,
     iter::{once, repeat},
     mem,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     str,
 };
 use tokio::io;
 
-use crate::{other, EntryType};
+use crate::{other, EntryType, LinkTarget, Name};
 
 /// A deterministic, arbitrary, non-zero timestamp that use used as `mtime`
 /// of headers when [`HeaderMode::Deterministic`] is used.
@@ -151,7 +151,7 @@ impl Header {
     /// too long) path name.
     ///
     /// UStar is also the basis used for pax archives.
-    pub fn new_ustar() -> Header {
+    pub(crate) fn new_ustar() -> Header {
         let mut header = Header {
             bytes: [0; BLOCK_SIZE as usize],
         };
@@ -260,13 +260,9 @@ impl Header {
     /// This is useful for initializing a `Header` from the OS's metadata from a
     /// file. By default, this will use `HeaderMode::Complete` to include all
     /// metadata.
-    pub fn set_metadata(&mut self, meta: &Metadata) {
-        self.fill_from(meta, HeaderMode::Complete);
-    }
-
     /// Sets only the metadata relevant to the given HeaderMode in this header
     /// from the metadata argument provided.
-    pub fn set_metadata_in_mode(&mut self, meta: &Metadata, mode: HeaderMode) {
+    pub(crate) fn set_metadata_in_mode(&mut self, meta: &Metadata, mode: HeaderMode) {
         self.fill_from(meta, mode);
     }
 
@@ -301,7 +297,7 @@ impl Header {
     }
 
     /// Encodes the `size` argument into the size field of this header.
-    pub fn set_size(&mut self, size: u64) {
+    pub(crate) fn set_size(&mut self, size: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().size, size);
     }
 
@@ -337,21 +333,21 @@ impl Header {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    /// Sets the path name for this header.
+    /// Sets the path name for this header from a validated archive member name.
     ///
-    /// This function will set the pathname listed in this header, encoding it
-    /// in the appropriate format. May fail if the path is too long or if the
-    /// path specified is not Unicode and this is a Windows platform. Will
-    /// strip out any "." path component, which signifies the current directory.
+    /// This bare-header setter accepts only ASCII names directly representable
+    /// in USTAR. Use [`crate::Builder`] named methods when a valid name needs a
+    /// PAX `path` extension, such as a non-ASCII or overlong name.
     ///
-    /// Note: This function does not support names over 100 bytes, or paths
-    /// over 255 bytes, even for formats that support longer names. Instead,
-    /// use `Builder` methods to insert a PAX path extension at the same time as
-    /// the file content.
-    pub fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
-        let path = p.as_ref();
+    pub(crate) fn set_path(&mut self, name: &Name) -> io::Result<()> {
+        if !name.as_str().is_ascii() {
+            return Err(pax_required("path"));
+        }
         if let Some(ustar) = self.as_ustar_mut() {
-            return ustar.set_path(path);
+            return ustar
+                .set_path(name)
+                .then_some(())
+                .ok_or_else(|| pax_required("path"));
         }
         Err(other("cannot set path on a non-USTAR header"))
     }
@@ -387,26 +383,48 @@ impl Header {
         }
     }
 
-    /// Sets the link name for this header.
+    /// Sets a hard-link destination for this header.
     ///
-    /// This function will set the linkname listed in this header, encoding it
-    /// in the appropriate format. May fail if the link name is too long or if
-    /// the path specified is not Unicode and this is a Windows platform. Will
-    /// strip out any "." path component, which signifies the current directory.
-    pub fn set_link_name<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
+    /// This bare-header setter accepts only ASCII [`Name`] values fitting in
+    /// the USTAR `linkname` field. Use [`crate::Builder::append_hard_link`] for
+    /// a value requiring a PAX `linkpath` extension.
+    pub(crate) fn set_hard_link_name(&mut self, name: &Name) -> io::Result<()> {
+        if !name.as_str().is_ascii() {
+            return Err(pax_required("linkpath"));
+        }
         if self.as_ustar().is_none() {
             return Err(other("cannot set link name on a non-USTAR header"));
         }
-        self._set_link_name(p.as_ref())
+        self.set_link_name_bytes(name.as_bytes())
+            .then_some(())
+            .ok_or_else(|| pax_required("linkpath"))
     }
 
-    fn _set_link_name(&mut self, path: &Path) -> io::Result<()> {
-        copy_path_into(&mut self.as_old_mut().linkname, path, true).map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!("{} when setting link name for {}", err, self.path_lossy()),
-            )
-        })
+    /// Sets a symbolic-link target for this header.
+    ///
+    /// This bare-header setter accepts only ASCII [`LinkTarget`] values fitting
+    /// in the USTAR `linkname` field. Use [`crate::Builder::append_symlink`]
+    /// for a value requiring a PAX `linkpath` extension.
+    pub(crate) fn set_symlink_target(&mut self, target: &LinkTarget) -> io::Result<()> {
+        if !target.as_str().is_ascii() {
+            return Err(pax_required("linkpath"));
+        }
+        if self.as_ustar().is_none() {
+            return Err(other("cannot set link name on a non-USTAR header"));
+        }
+        self.set_link_name_bytes(target.as_bytes())
+            .then_some(())
+            .ok_or_else(|| pax_required("linkpath"))
+    }
+
+    fn set_link_name_bytes(&mut self, value: &[u8]) -> bool {
+        let linkname = &mut self.as_old_mut().linkname;
+        if value.len() > linkname.len() {
+            return false;
+        }
+        linkname.fill(0);
+        linkname[..value.len()].copy_from_slice(value);
+        true
     }
 
     /// Returns the mode bits for this file
@@ -424,7 +442,7 @@ impl Header {
     }
 
     /// Encodes the `mode` provided into this header.
-    pub fn set_mode(&mut self, mode: u32) {
+    pub(crate) fn set_mode(&mut self, mode: u32) {
         octal_into(&mut self.as_old_mut().mode, mode);
     }
 
@@ -441,7 +459,7 @@ impl Header {
     }
 
     /// Encodes the `uid` provided into this header.
-    pub fn set_uid(&mut self, uid: u64) {
+    pub(crate) fn set_uid(&mut self, uid: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().uid, uid);
     }
 
@@ -456,7 +474,7 @@ impl Header {
     }
 
     /// Encodes the `gid` provided into this header.
-    pub fn set_gid(&mut self, gid: u64) {
+    pub(crate) fn set_gid(&mut self, gid: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().gid, gid);
     }
 
@@ -474,7 +492,7 @@ impl Header {
     ///
     /// Note that this time is typically a number of seconds passed since
     /// January 1, 1970.
-    pub fn set_mtime(&mut self, mtime: u64) {
+    pub(crate) fn set_mtime(&mut self, mtime: u64) {
         num_field_wrapper_into(&mut self.as_old_mut().mtime, mtime);
     }
 
@@ -506,17 +524,6 @@ impl Header {
         }
     }
 
-    /// Sets the username inside this header.
-    ///
-    /// This function will return an error if this header format cannot encode a
-    /// user name or the name is too long.
-    pub fn set_username(&mut self, name: &str) -> io::Result<()> {
-        if let Some(ustar) = self.as_ustar_mut() {
-            return ustar.set_username(name);
-        }
-        Err(other("cannot set username on a non-USTAR header"))
-    }
-
     /// Return the group name of the owner of this file.
     ///
     /// A return value of `Ok(Some(..))` indicates that the group name was
@@ -545,17 +552,6 @@ impl Header {
         }
     }
 
-    /// Sets the group name inside this header.
-    ///
-    /// This function will return an error if this header format cannot encode a
-    /// group name or the name is too long.
-    pub fn set_groupname(&mut self, name: &str) -> io::Result<()> {
-        if let Some(ustar) = self.as_ustar_mut() {
-            return ustar.set_groupname(name);
-        }
-        Err(other("cannot set group name on a non-USTAR header"))
-    }
-
     /// Returns the device major number, if present.
     ///
     /// This field may not be present in all archives, and it may not be
@@ -577,7 +573,7 @@ impl Header {
     ///
     /// This function will return an error if this header format cannot encode a
     /// major device number.
-    pub fn set_device_major(&mut self, major: u32) -> io::Result<()> {
+    pub(crate) fn set_device_major(&mut self, major: u32) -> io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_major(major);
             Ok(())
@@ -607,7 +603,7 @@ impl Header {
     ///
     /// This function will return an error if this header format cannot encode a
     /// minor device number.
-    pub fn set_device_minor(&mut self, minor: u32) -> io::Result<()> {
+    pub(crate) fn set_device_minor(&mut self, minor: u32) -> io::Result<()> {
         if let Some(ustar) = self.as_ustar_mut() {
             ustar.set_device_minor(minor);
             Ok(())
@@ -625,7 +621,7 @@ impl Header {
     ///
     /// GNU extension entry types cannot be written directly. The builder uses
     /// PAX extension entries when a USTAR header cannot represent an entry.
-    pub fn set_entry_type(&mut self, ty: EntryType) -> io::Result<()> {
+    pub(crate) fn set_entry_type(&mut self, ty: EntryType) -> io::Result<()> {
         if self.as_ustar().is_none() {
             return Err(other("cannot set entry type on a non-USTAR header"));
         }
@@ -656,7 +652,7 @@ impl Header {
 
     /// Sets the checksum field of this header based on the current fields in
     /// this header.
-    pub fn set_cksum(&mut self) {
+    pub(crate) fn set_cksum(&mut self) {
         let cksum = self.calculate_cksum();
         octal_into(&mut self.as_old_mut().cksum, cksum);
     }
@@ -913,61 +909,29 @@ impl UstarHeader {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    fn set_path<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
-        self._set_path(p.as_ref())
-    }
-
-    fn _set_path(&mut self, path: &Path) -> io::Result<()> {
-        // This can probably be optimized quite a bit more, but for now just do
-        // something that's relatively easy and readable.
-        //
-        // First up, if the path fits within `self.name` then we just shove it
-        // in there. If not then we try to split it between some existing path
-        // components where it can fit in name/prefix. To do that we peel off
-        // enough until the path fits in `prefix`, then we try to put both
-        // halves into their destination.
-        let bytes = path2bytes(path)?;
-        let (maxnamelen, maxprefixlen) = (self.name.len(), self.prefix.len());
-        if bytes.len() <= maxnamelen {
-            copy_path_into(&mut self.name, path, false).map_err(|err| {
-                io::Error::new(
-                    err.kind(),
-                    format!("{} when setting path for {}", err, self.path_lossy()),
-                )
-            })?;
+    fn set_path(&mut self, name: &Name) -> bool {
+        let bytes = name.as_bytes();
+        let (prefix, suffix) = if bytes.len() <= self.name.len() {
+            (&[][..], bytes)
         } else {
-            let mut prefix = path;
-            let mut prefixlen;
-            loop {
-                match prefix.parent() {
-                    Some(parent) => prefix = parent,
-                    None => {
-                        return Err(other(&format!(
-                            "path cannot be split to be inserted into archive: {}",
-                            path.display()
-                        )));
-                    }
-                }
-                prefixlen = path2bytes(prefix)?.len();
-                if prefixlen <= maxprefixlen {
-                    break;
-                }
-            }
-            copy_path_into(&mut self.prefix, prefix, false).map_err(|err| {
-                io::Error::new(
-                    err.kind(),
-                    format!("{} when setting path for {}", err, self.path_lossy()),
-                )
-            })?;
-            let path = bytes2path(Cow::Borrowed(&bytes[prefixlen + 1..]))?;
-            copy_path_into(&mut self.name, &path, false).map_err(|err| {
-                io::Error::new(
-                    err.kind(),
-                    format!("{} when setting path for {}", err, self.path_lossy()),
-                )
-            })?;
-        }
-        Ok(())
+            let Some(split) = bytes.iter().enumerate().rev().find_map(|(index, byte)| {
+                let suffix = &bytes[index + 1..];
+                (*byte == b'/'
+                    && index <= self.prefix.len()
+                    && !suffix.is_empty()
+                    && suffix.len() <= self.name.len())
+                .then_some(index)
+            }) else {
+                return false;
+            };
+            (&bytes[..split], &bytes[split + 1..])
+        };
+
+        self.name.fill(0);
+        self.prefix.fill(0);
+        self.name[..suffix.len()].copy_from_slice(suffix);
+        self.prefix[..prefix.len()].copy_from_slice(prefix);
+        true
     }
 
     /// See `Header::username_bytes`
@@ -975,27 +939,9 @@ impl UstarHeader {
         truncate(&self.uname)
     }
 
-    fn set_username(&mut self, name: &str) -> io::Result<()> {
-        copy_into(&mut self.uname, name.as_bytes()).map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!("{} when setting username for {}", err, self.path_lossy()),
-            )
-        })
-    }
-
     /// See `Header::groupname_bytes`
     pub fn groupname_bytes(&self) -> &[u8] {
         truncate(&self.gname)
-    }
-
-    fn set_groupname(&mut self, name: &str) -> io::Result<()> {
-        copy_into(&mut self.gname, name.as_bytes()).map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!("{} when setting groupname for {}", err, self.path_lossy()),
-            )
-        })
     }
 
     /// See `Header::device_major`
@@ -1330,141 +1276,10 @@ fn truncate(slice: &[u8]) -> &[u8] {
     }
 }
 
-/// Copies `bytes` into the `slot` provided, returning an error if the `bytes`
-/// array is too long or if it contains any nul bytes.
-fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
-    if bytes.len() > slot.len() {
-        Err(other("provided value is too long"))
-    } else if bytes.contains(&0) {
-        Err(other("provided value contains a nul byte"))
-    } else {
-        for (slot, val) in slot.iter_mut().zip(bytes.iter().chain(Some(&0))) {
-            *slot = *val;
-        }
-        Ok(())
-    }
-}
-
-fn copy_path_into_inner(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
-    let mut emitted = false;
-    let mut needs_slash = false;
-    for component in path.components() {
-        let bytes = path2bytes(Path::new(component.as_os_str()))?;
-        match (component, is_link_name) {
-            (Component::Prefix(..), false) | (Component::RootDir, false) => {
-                return Err(other("paths in archives must be relative"));
-            }
-            (Component::ParentDir, false) => {
-                return Err(other("paths in archives must not have `..`"));
-            }
-            // Allow "./" as the path
-            (Component::CurDir, false) if path.components().count() == 1 => {}
-            (Component::CurDir, false) => continue,
-            (Component::Normal(_), _) | (_, true) => {}
-        };
-        if needs_slash {
-            copy(&mut slot, b"/")?;
-        }
-        if bytes.contains(&b'/') {
-            if let Component::Normal(..) = component {
-                return Err(other("path component in archive cannot contain `/`"));
-            }
-        }
-        copy(&mut slot, &bytes)?;
-        if &*bytes != b"/" {
-            needs_slash = true;
-        }
-        emitted = true;
-    }
-    if !emitted {
-        return Err(other("paths in archives must have at least one component"));
-    }
-    if ends_with_slash(path) {
-        copy(&mut slot, b"/")?;
-    }
-    return Ok(());
-
-    fn copy(slot: &mut &mut [u8], bytes: &[u8]) -> io::Result<()> {
-        copy_into(slot, bytes)?;
-        let tmp = std::mem::take(slot);
-        *slot = &mut tmp[bytes.len()..];
-        Ok(())
-    }
-}
-
-/// Copies `path` into the `slot` provided
-///
-/// Returns an error if:
-///
-/// * the path is too long to fit
-/// * a nul byte was found
-/// * an invalid path component is encountered (e.g. a root path or parent dir)
-/// * the path itself is empty
-fn copy_path_into(slot: &mut [u8], path: &Path, is_link_name: bool) -> io::Result<()> {
-    copy_path_into_inner(slot, path, is_link_name)
-}
-
-pub(crate) fn path2pax_bytes(path: &Path) -> io::Result<Vec<u8>> {
-    path2pax_bytes_inner(path, false)
-}
-
-pub(crate) fn link_name2pax_bytes(path: &Path) -> io::Result<Vec<u8>> {
-    path2pax_bytes_inner(path, true)
-}
-
-fn path2pax_bytes_inner(path: &Path, is_link_name: bool) -> io::Result<Vec<u8>> {
-    let capacity = path2bytes(path)?
-        .len()
-        .checked_add(1)
-        .ok_or_else(|| other("path is too long"))?;
-    let mut bytes = vec![0; capacity];
-    copy_path_into(&mut bytes, path, is_link_name)?;
-    bytes.truncate(truncate(&bytes).len());
-    Ok(bytes)
-}
-
-#[cfg(target_arch = "wasm32")]
-fn ends_with_slash(p: &Path) -> bool {
-    p.to_string_lossy().ends_with('/')
-}
-
-#[cfg(windows)]
-fn ends_with_slash(p: &Path) -> bool {
-    let last = p.as_os_str().encode_wide().last();
-    last == Some(b'/' as u16) || last == Some(b'\\' as u16)
-}
-
-#[cfg(unix)]
-fn ends_with_slash(p: &Path) -> bool {
-    p.as_os_str().as_bytes().ends_with(b"/")
-}
-
-#[cfg(any(windows, target_arch = "wasm32"))]
-pub fn path2bytes(p: &Path) -> io::Result<Cow<'_, [u8]>> {
-    p.as_os_str()
-        .to_str()
-        .map(|s| s.as_bytes())
-        .ok_or_else(|| other(&format!("path {} was not valid Unicode", p.display())))
-        .map(|bytes| {
-            if bytes.contains(&b'\\') {
-                // Normalize to Unix-style path separators
-                let mut bytes = bytes.to_owned();
-                for b in &mut bytes {
-                    if *b == b'\\' {
-                        *b = b'/';
-                    }
-                }
-                Cow::Owned(bytes)
-            } else {
-                Cow::Borrowed(bytes)
-            }
-        })
-}
-
-#[cfg(unix)]
-/// On unix this will never fail
-pub fn path2bytes(p: &Path) -> io::Result<Cow<'_, [u8]>> {
-    Ok(Cow::Borrowed(p.as_os_str().as_bytes()))
+fn pax_required(field: &str) -> io::Error {
+    other(&format!(
+        "{field} requires a PAX extension; use Builder named methods when writing this entry"
+    ))
 }
 
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,7 @@ pub use crate::{
     entry::{Entry, Unpacked},
     entry_type::EntryType,
     error::TarError,
-    header::{
-        GnuExtSparseHeader, GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader,
-    },
+    header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader},
     pax::{PaxExtension, PaxExtensions},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@ pub use crate::{
     entry::{Entry, Unpacked},
     entry_type::EntryType,
     error::TarError,
-    header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader},
+    header::{
+        GnuExtSparseHeader, GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader,
+    },
     name::{LinkTarget, Name},
     pax::{PaxExtension, PaxExtensions},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,12 @@ use std::io::Error;
 
 pub use crate::{
     archive::{Archive, ArchiveBuilder, Entries},
-    builder::Builder,
+    builder::{Builder, EntryMetadata},
     entry::{Entry, Unpacked},
     entry_type::EntryType,
     error::TarError,
     header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader},
+    name::{LinkTarget, Name},
     pax::{PaxExtension, PaxExtensions},
 };
 
@@ -39,6 +40,7 @@ mod entry_type;
 mod error;
 mod fs;
 mod header;
+mod name;
 mod pax;
 
 fn other(msg: &str) -> Error {

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,312 @@
+use crate::other;
+use std::{
+    fmt, io,
+    path::{Component, Path, PathBuf},
+};
+
+/// A validated UTF-8 archive member name.
+///
+/// Archive member names are relative, contain no parent-directory components
+/// or Unicode control characters, and are normalized by removing interior `.`
+/// components. A sole `.` name and a trailing `/` are preserved.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Name(ValidatedUtf8);
+
+/// A validated UTF-8 symbolic-link target stored in an archive.
+///
+/// Link targets may be absolute or contain `.` and `..` components, because
+/// these values describe symbolic-link contents rather than archive members.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LinkTarget(ValidatedUtf8);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ValidatedUtf8(String);
+
+impl Name {
+    /// Returns this archive member name as UTF-8 text.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns this archive member name as a path.
+    pub fn as_path(&self) -> &Path {
+        self.0.as_path()
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl LinkTarget {
+    /// Returns this symbolic-link target as UTF-8 text.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns this symbolic-link target as a path.
+    pub fn as_path(&self) -> &Path {
+        self.0.as_path()
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<&Path> for Name {
+    type Error = io::Error;
+
+    fn try_from(path: &Path) -> io::Result<Self> {
+        let value = ValidatedUtf8::from_path(path, "archive names")?;
+        Ok(Self(ValidatedUtf8(canonicalize_name(value.as_path())?)))
+    }
+}
+
+impl TryFrom<&Path> for LinkTarget {
+    type Error = io::Error;
+
+    fn try_from(path: &Path) -> io::Result<Self> {
+        let value = ValidatedUtf8::from_path(path, "symbolic-link targets")?;
+        Ok(Self(ValidatedUtf8(canonicalize_link_target(
+            value.as_str(),
+        )?)))
+    }
+}
+
+macro_rules! impl_owned_value_behavior {
+    ($value:ty) => {
+        impl TryFrom<&str> for $value {
+            type Error = io::Error;
+
+            fn try_from(value: &str) -> io::Result<Self> {
+                Self::try_from(Path::new(value))
+            }
+        }
+
+        impl TryFrom<String> for $value {
+            type Error = io::Error;
+
+            fn try_from(value: String) -> io::Result<Self> {
+                Self::try_from(value.as_str())
+            }
+        }
+
+        impl TryFrom<&String> for $value {
+            type Error = io::Error;
+
+            fn try_from(value: &String) -> io::Result<Self> {
+                Self::try_from(value.as_str())
+            }
+        }
+
+        impl TryFrom<PathBuf> for $value {
+            type Error = io::Error;
+
+            fn try_from(value: PathBuf) -> io::Result<Self> {
+                Self::try_from(value.as_path())
+            }
+        }
+
+        impl TryFrom<&PathBuf> for $value {
+            type Error = io::Error;
+
+            fn try_from(value: &PathBuf) -> io::Result<Self> {
+                Self::try_from(value.as_path())
+            }
+        }
+
+        impl From<&$value> for $value {
+            fn from(value: &$value) -> Self {
+                value.clone()
+            }
+        }
+
+        impl AsRef<str> for $value {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl AsRef<Path> for $value {
+            fn as_ref(&self) -> &Path {
+                self.as_path()
+            }
+        }
+
+        impl fmt::Display for $value {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.as_str().fmt(formatter)
+            }
+        }
+    };
+}
+
+impl_owned_value_behavior!(Name);
+impl_owned_value_behavior!(LinkTarget);
+
+pub(crate) fn into_name<N>(name: N) -> io::Result<Name>
+where
+    N: TryInto<Name>,
+    N::Error: fmt::Display,
+{
+    name.try_into().map_err(|err| other(&err.to_string()))
+}
+
+pub(crate) fn into_link_target<T>(target: T) -> io::Result<LinkTarget>
+where
+    T: TryInto<LinkTarget>,
+    T::Error: fmt::Display,
+{
+    target.try_into().map_err(|err| other(&err.to_string()))
+}
+
+impl ValidatedUtf8 {
+    fn from_path(path: &Path, kind: &str) -> io::Result<Self> {
+        let value = path
+            .to_str()
+            .ok_or_else(|| other(&format!("{kind} must be valid UTF-8")))?;
+        if value.chars().any(char::is_control) {
+            return Err(other(&format!(
+                "{kind} must not contain Unicode control characters"
+            )));
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn as_path(&self) -> &Path {
+        Path::new(self.as_str())
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+fn canonicalize_name(path: &Path) -> io::Result<String> {
+    let count = path.components().count();
+    let mut result = String::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(other("paths in archives must be relative"));
+            }
+            Component::ParentDir => {
+                return Err(other("paths in archives must not have `..`"));
+            }
+            Component::CurDir if count != 1 => continue,
+            Component::CurDir => push_component(&mut result, "."),
+            Component::Normal(value) => {
+                push_component(
+                    &mut result,
+                    value.to_str().expect("already validated UTF-8"),
+                );
+            }
+        }
+    }
+    if result.is_empty() {
+        return Err(other("paths in archives must have at least one component"));
+    }
+    if ends_with_slash(path) && !result.ends_with('/') {
+        result.push('/');
+    }
+    Ok(result)
+}
+
+fn canonicalize_link_target(value: &str) -> io::Result<String> {
+    if value.is_empty() {
+        return Err(other(
+            "symbolic-link targets must have at least one component",
+        ));
+    }
+
+    #[cfg(any(windows, target_arch = "wasm32"))]
+    {
+        Ok(value.replace('\\', "/"))
+    }
+
+    #[cfg(unix)]
+    {
+        Ok(value.to_owned())
+    }
+}
+
+fn push_component(result: &mut String, component: &str) {
+    if !result.is_empty() {
+        result.push('/');
+    }
+    result.push_str(component);
+}
+
+#[cfg(any(windows, target_arch = "wasm32"))]
+fn ends_with_slash(path: &Path) -> bool {
+    path.to_string_lossy()
+        .as_bytes()
+        .last()
+        .is_some_and(|byte| *byte == b'/' || *byte == b'\\')
+}
+
+#[cfg(unix)]
+fn ends_with_slash(path: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().ends_with(b"/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LinkTarget, Name};
+    use std::path::Path;
+
+    #[test]
+    fn name_validation_and_normalization() {
+        assert_eq!(Name::try_from("filer").unwrap().as_str(), "filer");
+        assert_eq!(
+            Name::try_from("dossier/\u{e9}").unwrap().as_str(),
+            "dossier/\u{e9}"
+        );
+        assert_eq!(Name::try_from("./a/./b/").unwrap().as_str(), "a/b/");
+        assert_eq!(Name::try_from(".").unwrap().as_str(), ".");
+        assert!(Name::try_from("").is_err());
+        assert!(Name::try_from("/absolute").is_err());
+        assert!(Name::try_from("../outside").is_err());
+        assert!(Name::try_from("line\nbreak").is_err());
+        assert!(Name::try_from("control-\u{85}").is_err());
+    }
+
+    #[test]
+    fn link_target_validation_and_meaning() {
+        assert_eq!(
+            LinkTarget::try_from("../\u{e9}/file").unwrap().as_str(),
+            "../\u{e9}/file"
+        );
+        assert_eq!(
+            LinkTarget::try_from("/root/./file").unwrap().as_str(),
+            "/root/./file"
+        );
+        assert!(LinkTarget::try_from("").is_err());
+        assert!(LinkTarget::try_from("line\nbreak").is_err());
+        assert!(LinkTarget::try_from("control-\u{85}").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_names_require_utf8_and_preserve_backslashes() {
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+        assert!(Name::try_from(Path::new(OsStr::from_bytes(b"bad-\xff"))).is_err());
+        assert!(LinkTarget::try_from(Path::new(OsStr::from_bytes(b"bad-\xff"))).is_err());
+        assert_eq!(Name::try_from(r"foo\bar").unwrap().as_str(), r"foo\bar");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_names_normalize_separators() {
+        assert_eq!(Name::try_from(r"foo\bar").unwrap().as_str(), "foo/bar");
+        assert_eq!(LinkTarget::try_from(r"..\bar").unwrap().as_str(), "../bar");
+    }
+}

--- a/src/name.rs
+++ b/src/name.rs
@@ -5,191 +5,17 @@ use std::{
 };
 
 /// A validated UTF-8 archive member name.
-///
-/// Archive member names are relative, contain no parent-directory components
-/// or Unicode control characters, and are normalized by removing interior `.`
-/// components. A sole `.` name and a trailing `/` are preserved.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Name(ValidatedUtf8);
+pub struct Name(String);
 
 /// A validated UTF-8 symbolic-link target stored in an archive.
-///
-/// Link targets may be absolute or contain `.` and `..` components, because
-/// these values describe symbolic-link contents rather than archive members.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct LinkTarget(ValidatedUtf8);
+pub struct LinkTarget(String);
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct ValidatedUtf8(String);
-
-impl Name {
-    /// Returns this archive member name as UTF-8 text.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    /// Returns this archive member name as a path.
-    pub fn as_path(&self) -> &Path {
-        self.0.as_path()
-    }
-
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl LinkTarget {
-    /// Returns this symbolic-link target as UTF-8 text.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    /// Returns this symbolic-link target as a path.
-    pub fn as_path(&self) -> &Path {
-        self.0.as_path()
-    }
-
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl TryFrom<&Path> for Name {
-    type Error = io::Error;
-
-    fn try_from(path: &Path) -> io::Result<Self> {
-        let value = ValidatedUtf8::from_path(path, "archive names")?;
-        Ok(Self(ValidatedUtf8(canonicalize_name(value.as_path())?)))
-    }
-}
-
-impl TryFrom<&Path> for LinkTarget {
-    type Error = io::Error;
-
-    fn try_from(path: &Path) -> io::Result<Self> {
-        let value = ValidatedUtf8::from_path(path, "symbolic-link targets")?;
-        Ok(Self(ValidatedUtf8(canonicalize_link_target(
-            value.as_str(),
-        )?)))
-    }
-}
-
-macro_rules! impl_owned_value_behavior {
-    ($value:ty) => {
-        impl TryFrom<&str> for $value {
-            type Error = io::Error;
-
-            fn try_from(value: &str) -> io::Result<Self> {
-                Self::try_from(Path::new(value))
-            }
-        }
-
-        impl TryFrom<String> for $value {
-            type Error = io::Error;
-
-            fn try_from(value: String) -> io::Result<Self> {
-                Self::try_from(value.as_str())
-            }
-        }
-
-        impl TryFrom<&String> for $value {
-            type Error = io::Error;
-
-            fn try_from(value: &String) -> io::Result<Self> {
-                Self::try_from(value.as_str())
-            }
-        }
-
-        impl TryFrom<PathBuf> for $value {
-            type Error = io::Error;
-
-            fn try_from(value: PathBuf) -> io::Result<Self> {
-                Self::try_from(value.as_path())
-            }
-        }
-
-        impl TryFrom<&PathBuf> for $value {
-            type Error = io::Error;
-
-            fn try_from(value: &PathBuf) -> io::Result<Self> {
-                Self::try_from(value.as_path())
-            }
-        }
-
-        impl From<&$value> for $value {
-            fn from(value: &$value) -> Self {
-                value.clone()
-            }
-        }
-
-        impl AsRef<str> for $value {
-            fn as_ref(&self) -> &str {
-                self.as_str()
-            }
-        }
-
-        impl AsRef<Path> for $value {
-            fn as_ref(&self) -> &Path {
-                self.as_path()
-            }
-        }
-
-        impl fmt::Display for $value {
-            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                self.as_str().fmt(formatter)
-            }
-        }
-    };
-}
-
-impl_owned_value_behavior!(Name);
-impl_owned_value_behavior!(LinkTarget);
-
-pub(crate) fn into_name<N>(name: N) -> io::Result<Name>
-where
-    N: TryInto<Name>,
-    N::Error: fmt::Display,
-{
-    name.try_into().map_err(|err| other(&err.to_string()))
-}
-
-pub(crate) fn into_link_target<T>(target: T) -> io::Result<LinkTarget>
-where
-    T: TryInto<LinkTarget>,
-    T::Error: fmt::Display,
-{
-    target.try_into().map_err(|err| other(&err.to_string()))
-}
-
-impl ValidatedUtf8 {
-    fn from_path(path: &Path, kind: &str) -> io::Result<Self> {
-        let value = path
-            .to_str()
-            .ok_or_else(|| other(&format!("{kind} must be valid UTF-8")))?;
-        if value.chars().any(char::is_control) {
-            return Err(other(&format!(
-                "{kind} must not contain Unicode control characters"
-            )));
-        }
-        Ok(Self(value.to_owned()))
-    }
-
-    fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    fn as_path(&self) -> &Path {
-        Path::new(self.as_str())
-    }
-
-    fn as_bytes(&self) -> &[u8] {
-        self.as_str().as_bytes()
-    }
-}
-
-fn canonicalize_name(path: &Path) -> io::Result<String> {
-    let count = path.components().count();
+pub(crate) fn archive_name(path: &Path) -> io::Result<String> {
+    validate_utf8(path, "archive names")?;
     let mut result = String::new();
+    let sole_component = path.components().count() == 1;
     for component in path.components() {
         match component {
             Component::Prefix(_) | Component::RootDir => {
@@ -198,13 +24,10 @@ fn canonicalize_name(path: &Path) -> io::Result<String> {
             Component::ParentDir => {
                 return Err(other("paths in archives must not have `..`"));
             }
-            Component::CurDir if count != 1 => continue,
+            Component::CurDir if !sole_component => continue,
             Component::CurDir => push_component(&mut result, "."),
             Component::Normal(value) => {
-                push_component(
-                    &mut result,
-                    value.to_str().expect("already validated UTF-8"),
-                );
+                push_component(&mut result, value.to_str().expect("validated UTF-8"));
             }
         }
     }
@@ -217,21 +40,114 @@ fn canonicalize_name(path: &Path) -> io::Result<String> {
     Ok(result)
 }
 
-fn canonicalize_link_target(value: &str) -> io::Result<String> {
+pub(crate) fn link_target(path: &Path) -> io::Result<String> {
+    let value = validate_utf8(path, "symbolic-link targets")?;
     if value.is_empty() {
         return Err(other(
             "symbolic-link targets must have at least one component",
         ));
     }
-
     #[cfg(any(windows, target_arch = "wasm32"))]
-    {
-        Ok(value.replace('\\', "/"))
-    }
-
+    return Ok(value.replace('\\', "/"));
     #[cfg(unix)]
-    {
-        Ok(value.to_owned())
+    Ok(value.to_owned())
+}
+
+macro_rules! validated_value {
+    ($ty:ident, $validate:ident) => {
+        impl $ty {
+            /// Returns this validated value as UTF-8 text.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            /// Returns this validated value as a path.
+            pub fn as_path(&self) -> &Path {
+                Path::new(self.as_str())
+            }
+        }
+
+        impl TryFrom<&Path> for $ty {
+            type Error = io::Error;
+            fn try_from(path: &Path) -> io::Result<Self> {
+                $validate(path).map(Self)
+            }
+        }
+
+        impl TryFrom<&str> for $ty {
+            type Error = io::Error;
+            fn try_from(value: &str) -> io::Result<Self> {
+                Self::try_from(Path::new(value))
+            }
+        }
+
+        impl TryFrom<String> for $ty {
+            type Error = io::Error;
+            fn try_from(value: String) -> io::Result<Self> {
+                Self::try_from(value.as_str())
+            }
+        }
+
+        impl TryFrom<&String> for $ty {
+            type Error = io::Error;
+            fn try_from(value: &String) -> io::Result<Self> {
+                Self::try_from(value.as_str())
+            }
+        }
+
+        impl TryFrom<PathBuf> for $ty {
+            type Error = io::Error;
+            fn try_from(value: PathBuf) -> io::Result<Self> {
+                Self::try_from(value.as_path())
+            }
+        }
+
+        impl TryFrom<&PathBuf> for $ty {
+            type Error = io::Error;
+            fn try_from(value: &PathBuf) -> io::Result<Self> {
+                Self::try_from(value.as_path())
+            }
+        }
+
+        impl From<&$ty> for $ty {
+            fn from(value: &$ty) -> Self {
+                value.clone()
+            }
+        }
+
+        impl AsRef<str> for $ty {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl AsRef<Path> for $ty {
+            fn as_ref(&self) -> &Path {
+                self.as_path()
+            }
+        }
+
+        impl fmt::Display for $ty {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.as_str().fmt(formatter)
+            }
+        }
+    };
+}
+
+validated_value!(Name, archive_name);
+validated_value!(LinkTarget, link_target);
+
+fn validate_utf8<'a>(path: &'a Path, kind: &str) -> io::Result<&'a str> {
+    let value = path
+        .to_str()
+        .ok_or_else(|| other(&format!("{kind} must be valid UTF-8")))?;
+    if value.chars().any(char::is_control) {
+        Err(other(&format!(
+            "{kind} must not contain Unicode control characters"
+        )))
+    } else {
+        Ok(value)
     }
 }
 
@@ -253,14 +169,12 @@ fn ends_with_slash(path: &Path) -> bool {
 #[cfg(unix)]
 fn ends_with_slash(path: &Path) -> bool {
     use std::os::unix::ffi::OsStrExt;
-
     path.as_os_str().as_bytes().ends_with(b"/")
 }
 
 #[cfg(test)]
 mod tests {
     use super::{LinkTarget, Name};
-    use std::path::Path;
 
     #[test]
     fn name_validation_and_normalization() {
@@ -271,11 +185,15 @@ mod tests {
         );
         assert_eq!(Name::try_from("./a/./b/").unwrap().as_str(), "a/b/");
         assert_eq!(Name::try_from(".").unwrap().as_str(), ".");
-        assert!(Name::try_from("").is_err());
-        assert!(Name::try_from("/absolute").is_err());
-        assert!(Name::try_from("../outside").is_err());
-        assert!(Name::try_from("line\nbreak").is_err());
-        assert!(Name::try_from("control-\u{85}").is_err());
+        for invalid in [
+            "",
+            "/absolute",
+            "../outside",
+            "line\nbreak",
+            "control-\u{85}",
+        ] {
+            assert!(Name::try_from(invalid).is_err());
+        }
     }
 
     #[test]
@@ -288,18 +206,18 @@ mod tests {
             LinkTarget::try_from("/root/./file").unwrap().as_str(),
             "/root/./file"
         );
-        assert!(LinkTarget::try_from("").is_err());
-        assert!(LinkTarget::try_from("line\nbreak").is_err());
-        assert!(LinkTarget::try_from("control-\u{85}").is_err());
+        for invalid in ["", "line\nbreak", "control-\u{85}"] {
+            assert!(LinkTarget::try_from(invalid).is_err());
+        }
     }
 
     #[cfg(unix)]
     #[test]
     fn unix_names_require_utf8_and_preserve_backslashes() {
-        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
-
-        assert!(Name::try_from(Path::new(OsStr::from_bytes(b"bad-\xff"))).is_err());
-        assert!(LinkTarget::try_from(Path::new(OsStr::from_bytes(b"bad-\xff"))).is_err());
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt, path::Path};
+        let invalid = Path::new(OsStr::from_bytes(b"bad-\xff"));
+        assert!(Name::try_from(invalid).is_err());
+        assert!(LinkTarget::try_from(invalid).is_err());
         assert_eq!(Name::try_from(r"foo\bar").unwrap().as_str(), r"foo\bar");
     }
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -11,13 +11,11 @@ use std::{
 };
 use tokio::{
     fs::{self, File},
-    io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{self, AsyncRead, AsyncReadExt, AsyncWriteExt},
 };
 use tokio_stream::*;
 
-use async_tar::{
-    Archive, ArchiveBuilder, Builder, EntryType, GnuHeader, Header, OldHeader, UstarHeader,
-};
+use async_tar::{Archive, ArchiveBuilder, Builder, EntryMetadata, Header, OldHeader, UstarHeader};
 use filetime::FileTime;
 use tempfile::{Builder as TempBuilder, TempDir};
 
@@ -42,14 +40,6 @@ fn old_header() -> OldHeader {
     header
 }
 
-fn gnu_header() -> GnuHeader {
-    let mut header: GnuHeader = unsafe { std::mem::zeroed() };
-    header.magic = *b"ustar ";
-    header.version = *b" \0";
-    header.mtime = *b"00000000000\0";
-    header
-}
-
 fn raw_old_header(path: &[u8], entry_type: u8, size: u64) -> OldHeader {
     let mut header = old_header();
     header.name[..path.len()].copy_from_slice(path);
@@ -57,7 +47,7 @@ fn raw_old_header(path: &[u8], entry_type: u8, size: u64) -> OldHeader {
     encode_octal(&mut header.mode, 0o644);
     encode_octal(&mut header.uid, 0);
     encode_octal(&mut header.gid, 0);
-    encode_octal(&mut header.size, size);
+    encode_numeric(&mut header.size, size);
     encode_octal(&mut header.mtime, 0);
     let cksum = raw_header_checksum(header.as_header());
     encode_octal(&mut header.cksum, cksum as u64);
@@ -73,7 +63,7 @@ fn raw_ustar_header(path: &[u8], entry_type: u8, size: u64) -> UstarHeader {
     encode_octal(&mut header.mode, 0o644);
     encode_octal(&mut header.uid, 0);
     encode_octal(&mut header.gid, 0);
-    encode_octal(&mut header.size, size);
+    encode_numeric(&mut header.size, size);
     encode_octal(&mut header.mtime, 0);
     let cksum = raw_header_checksum(header.as_header());
     encode_octal(&mut header.cksum, cksum as u64);
@@ -86,6 +76,18 @@ fn encode_octal(dst: &mut [u8], value: u64) {
     for (slot, value) in dst.iter_mut().rev().zip(value) {
         *slot = value;
     }
+}
+
+fn encode_numeric(dst: &mut [u8], value: u64) {
+    if value < 8_589_934_592 {
+        encode_octal(dst, value);
+        return;
+    }
+
+    dst.fill(0);
+    let offset = dst.len() - std::mem::size_of::<u64>();
+    dst[offset..].copy_from_slice(&value.to_be_bytes());
+    dst[0] |= 0x80;
 }
 
 fn raw_header_checksum(header: &Header) -> u32 {
@@ -103,15 +105,11 @@ fn raw_header_checksum(header: &Header) -> u32 {
         .sum()
 }
 
-async fn append_raw<W: AsyncWrite + Send + Unpin>(
-    builder: &mut Builder<W>,
-    header: &Header,
-    data: &[u8],
-) {
-    t!(builder.get_mut().write_all(header.as_bytes()).await);
-    t!(builder.get_mut().write_all(data).await);
+fn append_raw(bytes: &mut Vec<u8>, header: &Header, data: &[u8]) {
+    bytes.extend_from_slice(header.as_bytes());
+    bytes.extend_from_slice(data);
     let padding = (512 - data.len() % 512) % 512;
-    t!(builder.get_mut().write_all(&vec![0; padding]).await);
+    bytes.extend_from_slice(&vec![0; padding]);
 }
 
 async fn pax_records<R: AsyncRead + Unpin>(
@@ -183,8 +181,7 @@ async fn simple_concat() {
 #[tokio::test]
 async fn header_impls() {
     let mut ar = Archive::new(Cursor::new(tar!("simple.tar")));
-    let hn = Header::new_ustar();
-    let hnb = hn.as_bytes();
+    let hnb = [0; 512];
     let mut entries = t!(ar.entries());
     while let Some(file) = entries.next().await {
         let file = t!(file);
@@ -199,8 +196,7 @@ async fn header_impls() {
 #[tokio::test]
 async fn header_impls_missing_last_header() {
     let mut ar = Archive::new(Cursor::new(tar!("simple_missing_last_header.tar")));
-    let hn = Header::new_ustar();
-    let hnb = hn.as_bytes();
+    let hnb = [0; 512];
     let mut entries = t!(ar.entries());
 
     while let Some(file) = entries.next().await {
@@ -263,53 +259,11 @@ async fn writing_files() {
 }
 
 #[tokio::test]
-async fn builder_append_rejects_non_ustar_writer_headers() {
-    let mut ar = Builder::new(Vec::new());
-
-    let old = old_header();
-    assert!(ar.append(old.as_header(), &[][..]).await.is_err());
-
-    let gnu = gnu_header();
-    assert!(ar.append(gnu.as_header(), &[][..]).await.is_err());
-
-    for entry_type in [
-        EntryType::GNULongName,
-        EntryType::GNULongLink,
-        EntryType::GNUSparse,
-    ] {
-        let mut gnu_extension = Header::new_ustar();
-        t!(gnu_extension.set_path("gnu-extension"));
-        assert!(gnu_extension.set_entry_type(entry_type).is_err());
-        assert_eq!(gnu_extension.entry_type(), EntryType::Regular);
-    }
-    for typeflag in [b'L', b'K', b'S'] {
-        let gnu_extension = raw_ustar_header(b"gnu-extension", typeflag, 0);
-        assert!(ar.append(gnu_extension.as_header(), &[][..]).await.is_err());
-    }
-
-    let unknown_extension = raw_ustar_header(b"unknown-extension", b'Z', 0);
-    assert!(ar
-        .append(unknown_extension.as_header(), &[][..])
-        .await
-        .is_err());
-
-    let mut base256 = Header::new_ustar();
-    t!(base256.set_path("base-256"));
-    base256.set_uid(2_097_152);
-    base256.set_cksum();
-    assert!(ar.append(&base256, &[][..]).await.is_err());
-
-    assert!(ar.get_ref().is_empty());
-}
-
-#[tokio::test]
 async fn append_data_long_path_uses_pax() {
     let mut ar = Builder::new(Vec::new());
     let long = "path".repeat(200);
-    let mut header = Header::new_ustar();
-    header.set_size(4);
 
-    t!(ar.append_data(&mut header, &long, "data".as_bytes()).await);
+    t!(ar.append_data(&long, 4, "data".as_bytes()).await);
 
     let contents = t!(ar.into_inner().await);
     let mut ar = Archive::new(&contents[..]);
@@ -332,19 +286,65 @@ async fn append_data_long_path_uses_pax() {
 }
 
 #[tokio::test]
+async fn append_data_short_non_ascii_path_uses_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let path = "caf\u{e9}.txt";
+
+    t!(ar.append_data(path, 0, &[][..]).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![("path".to_owned(), path.to_owned())]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().as_ustar().is_some());
+    assert!(payload.header().as_gnu().is_none());
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+    assert!(entries.next().await.is_none());
+
+    let mut decoded = Archive::new(&contents[..]);
+    let mut entries = t!(decoded.entries());
+    let entry = t!(entries.next().await.unwrap());
+    assert_eq!(&*t!(entry.path_bytes()), path.as_bytes());
+}
+
+#[tokio::test]
+async fn append_data_rejects_control_paths() {
+    for path in [
+        "control-\u{1}.txt",
+        "tab\tpath",
+        "delete-\u{7f}.txt",
+        "c1-\u{85}.txt",
+    ] {
+        let mut ar = Builder::new(Vec::new());
+
+        let err = ar.append_data(path, 0, &[][..]).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Unicode control characters"),
+            "{err}"
+        );
+        assert!(ar.get_ref().is_empty());
+    }
+}
+
+#[tokio::test]
 async fn append_data_numeric_overflows_use_pax() {
     let mut ar = Builder::new(Vec::new());
     let path = "numeric-overflow-path".repeat(30);
     let uid = 2_097_152 + 7;
     let gid = 2_097_152 + 9;
     let mtime = 8_589_934_592 + 11;
-    let mut header = Header::new_ustar();
-    header.set_size(0);
-    header.set_uid(uid);
-    header.set_gid(gid);
-    header.set_mtime(mtime);
+    let metadata = EntryMetadata::new().uid(uid).gid(gid).mtime(mtime);
 
-    t!(ar.append_data(&mut header, &path, &[][..]).await);
+    t!(ar
+        .append_data_with_metadata(&path, 0, metadata, &[][..])
+        .await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -382,13 +382,11 @@ async fn append_data_numeric_ustar_limits_do_not_use_pax() {
     let uid = 2_097_151;
     let gid = 2_097_151;
     let mtime = 8_589_934_591;
-    let mut header = Header::new_ustar();
-    header.set_size(0);
-    header.set_uid(uid);
-    header.set_gid(gid);
-    header.set_mtime(mtime);
+    let metadata = EntryMetadata::new().uid(uid).gid(gid).mtime(mtime);
 
-    t!(ar.append_data(&mut header, "limits", &[][..]).await);
+    t!(ar
+        .append_data_with_metadata("limits", 0, metadata, &[][..])
+        .await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -405,10 +403,8 @@ async fn append_data_numeric_ustar_limits_do_not_use_pax() {
 async fn append_data_size_overflow_uses_pax() {
     let mut ar = Builder::new(Vec::new());
     let size = 8_589_934_592;
-    let mut header = Header::new_ustar();
-    header.set_size(size);
 
-    t!(ar.append_data(&mut header, "sized", &[][..]).await);
+    t!(ar.append_data("sized", size, &[][..]).await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -424,6 +420,30 @@ async fn append_data_size_overflow_uses_pax() {
 }
 
 #[tokio::test]
+async fn generated_entries_have_conventional_default_modes() {
+    let mut ar = Builder::new(Vec::new());
+    t!(ar.append_data("file", 0, &[][..]).await);
+    t!(ar.append_directory("directory").await);
+    t!(ar.append_hard_link("hard-link", "file").await);
+    t!(ar.append_symlink("symlink", "file").await);
+    t!(ar
+        .append_data_with_metadata("metadata-file", 0, EntryMetadata::new().mtime(42), &[][..])
+        .await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut ar = Archive::new(&contents[..]);
+    let mut entries = t!(ar.entries());
+    assert_eq!(t!(t!(entries.next().await.unwrap()).header().mode()), 0o644);
+    assert_eq!(t!(t!(entries.next().await.unwrap()).header().mode()), 0o755);
+    assert_eq!(t!(t!(entries.next().await.unwrap()).header().mode()), 0o644);
+    assert_eq!(t!(t!(entries.next().await.unwrap()).header().mode()), 0o777);
+    let metadata_file = t!(entries.next().await.unwrap());
+    assert_eq!(t!(metadata_file.header().mode()), 0o644);
+    assert_eq!(t!(metadata_file.header().mtime()), 42);
+    assert!(entries.next().await.is_none());
+}
+
+#[tokio::test]
 async fn large_filename() {
     let mut ar = Builder::new(Vec::new());
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
@@ -434,22 +454,18 @@ async fn large_filename() {
     t!(file.flush().await);
 
     let filename = "abcd/".repeat(50);
-    let mut header = Header::new_ustar();
-    header.set_path(&filename).unwrap();
-    header.set_metadata(&t!(fs::metadata(&path).await));
-    header.set_cksum();
-    t!(ar.append(&header, &b"test"[..]).await);
+    t!(ar.append_data(&filename, 4, &b"test"[..]).await);
     let too_long = "abcd".repeat(200);
     t!(ar
         .append_file(&too_long, &mut t!(File::open(&path).await))
         .await);
-    t!(ar.append_data(&mut header, &too_long, &b"test"[..]).await);
+    t!(ar.append_data(&too_long, 4, &b"test"[..]).await);
 
     let rd = Cursor::new(t!(ar.into_inner().await));
     let mut ar = Archive::new(rd);
     let mut entries = t!(ar.entries());
 
-    // The short entry added with `append`
+    // The directly representable generated entry
     let mut f = entries.next().await.unwrap().unwrap();
     assert_eq!(&*f.header().path_bytes(), filename.as_bytes());
     assert_eq!(f.header().size().unwrap(), 4);
@@ -484,15 +500,11 @@ async fn large_filename() {
 async fn large_filename_with_dot_dot_at_100_byte_mark() {
     let mut ar = Builder::new(Vec::new());
 
-    let mut header = Header::new_ustar();
-    header.set_mode(0o644);
-    header.set_size(4);
-
     let mut long_name_with_dot_dot = "tdir/".repeat(19);
     long_name_with_dot_dot.push_str("tt/..file");
 
     t!(ar
-        .append_data(&mut header, &long_name_with_dot_dot, b"test".as_slice())
+        .append_data(&long_name_with_dot_dot, 4, b"test".as_slice())
         .await);
 
     let rd = Cursor::new(t!(ar.into_inner().await));
@@ -748,7 +760,7 @@ async fn append_dir_all_blank_dest() {
     t!(file2.flush().await);
 
     let mut ar = Builder::new(Vec::new());
-    t!(ar.append_dir_all("", base_dir).await);
+    t!(ar.append_dir_all_at_root(base_dir).await);
     let data = t!(ar.into_inner().await);
 
     let mut ar = Archive::new(Cursor::new(data));
@@ -806,13 +818,13 @@ async fn extracting_duplicate_dirs() {
 async fn unpack_old_style_bsd_dir() {
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
-
+    let mut bytes = Vec::new();
     let header = raw_old_header(b"testdir/", b'0', 0);
-    append_raw(&mut ar, header.as_header(), &[]).await;
+    append_raw(&mut bytes, header.as_header(), &[]);
+    bytes.extend_from_slice(&[0; 1024]);
 
     // Extracting
-    let rdr = Cursor::new(t!(ar.into_inner().await));
+    let rdr = Cursor::new(bytes);
     let mut ar = Archive::new(rdr);
     t!(ar.unpack(td.path()).await);
 
@@ -839,12 +851,7 @@ async fn handling_incorrect_file_size() {
     t!(file.write_all(b"").await);
     t!(file.flush().await);
     let mut file = t!(File::open(&path).await);
-    let mut header = Header::new_ustar();
-    t!(header.set_path("somepath"));
-    header.set_metadata(&t!(file.metadata().await));
-    header.set_size(2048); // past the end of file null blocks
-    header.set_cksum();
-    t!(ar.append(&header, &mut file).await);
+    t!(ar.append_data("somepath", 2048, &mut file).await); // past the end of file null blocks
 
     // Extracting
     let rdr = Cursor::new(t!(ar.into_inner().await));
@@ -870,46 +877,41 @@ async fn extracting_malicious_tarball() {
     let mut evil_tar = Vec::new();
 
     evil_tar = {
-        let mut a = Builder::new(evil_tar);
-        async fn append<R: AsyncWrite + Send + Unpin>(a: &mut Builder<R>, path: &'static str) {
-            let mut validated = Header::new_ustar();
-            assert!(validated.set_path(path).is_err(), "was ok: {:?}", path);
-
+        fn append(a: &mut Vec<u8>, path: &'static str) {
             let header = raw_ustar_header(path.as_bytes(), b'0', 1);
-            t!(a.append(header.as_header(), io::repeat(1).take(1)).await);
+            append_raw(a, header.as_header(), &[1]);
         }
 
-        append(&mut a, "/tmp/abs_evil.txt").await;
+        append(&mut evil_tar, "/tmp/abs_evil.txt");
         // std parse `//` as UNC path, see rust-lang/rust#100833
         append(
-            &mut a,
+            &mut evil_tar,
             #[cfg(not(windows))]
             "//tmp/abs_evil2.txt",
             #[cfg(windows)]
             "C://tmp/abs_evil2.txt",
-        )
-        .await;
-        append(&mut a, "///tmp/abs_evil3.txt").await;
-        append(&mut a, "/./tmp/abs_evil4.txt").await;
+        );
+        append(&mut evil_tar, "///tmp/abs_evil3.txt");
+        append(&mut evil_tar, "/./tmp/abs_evil4.txt");
         append(
-            &mut a,
+            &mut evil_tar,
             #[cfg(not(windows))]
             "//./tmp/abs_evil5.txt",
             #[cfg(windows)]
             "C://./tmp/abs_evil5.txt",
-        )
-        .await;
-        append(&mut a, "///./tmp/abs_evil6.txt").await;
-        append(&mut a, "/../tmp/rel_evil.txt").await;
-        append(&mut a, "../rel_evil2.txt").await;
-        append(&mut a, "./../rel_evil3.txt").await;
-        append(&mut a, "some/../../rel_evil4.txt").await;
-        append(&mut a, "").await;
-        append(&mut a, "././//./..").await;
-        append(&mut a, "..").await;
-        append(&mut a, "/////////..").await;
-        append(&mut a, "/////////").await;
-        a.into_inner().await.unwrap()
+        );
+        append(&mut evil_tar, "///./tmp/abs_evil6.txt");
+        append(&mut evil_tar, "/../tmp/rel_evil.txt");
+        append(&mut evil_tar, "../rel_evil2.txt");
+        append(&mut evil_tar, "./../rel_evil3.txt");
+        append(&mut evil_tar, "some/../../rel_evil4.txt");
+        append(&mut evil_tar, "");
+        append(&mut evil_tar, "././//./..");
+        append(&mut evil_tar, "..");
+        append(&mut evil_tar, "/////////..");
+        append(&mut evil_tar, "/////////");
+        evil_tar.extend_from_slice(&[0; 1024]);
+        evil_tar
     };
 
     let mut ar = Archive::new(&evil_tar[..]);
@@ -1066,10 +1068,10 @@ async fn backslash_treated_well() {
     }
 
     // Unpack an archive with a backslash in the name
-    let mut ar = Builder::new(Vec::<u8>::new());
+    let mut data = Vec::new();
     let header = raw_ustar_header(b"foo\\bar", b'0', 0);
-    t!(ar.append(header.as_header(), &mut io::empty()).await);
-    let data = t!(ar.into_inner().await);
+    append_raw(&mut data, header.as_header(), &[]);
+    data.extend_from_slice(&[0; 1024]);
     let mut ar = Archive::new(&data[..]);
     let f = t!(t!(ar.entries()).next().await.unwrap());
     assert_eq!(t!(f.header().path()).to_str(), Some("foo\\bar"));
@@ -1087,8 +1089,11 @@ async fn nul_bytes_in_path() {
     let nul_path = OsStr::from_bytes(b"foo\0");
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
     let mut ar = Builder::new(Vec::<u8>::new());
-    let err = ar.append_dir(nul_path, td.path()).await.unwrap_err();
-    assert!(err.to_string().contains("contains a nul byte"));
+    let err = ar
+        .append_dir(Path::new(nul_path), td.path())
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Unicode control characters"));
 }
 
 #[tokio::test]
@@ -1235,17 +1240,11 @@ async fn pax_precedence() {
 
 #[tokio::test]
 async fn long_name_trailing_nul() {
-    let mut b = Builder::new(Vec::<u8>::new());
-
+    let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'L', 4);
-    append_raw(&mut b, h.as_header(), b"foo\0").await;
-    let mut h = Header::new_ustar();
-
-    t!(h.set_path("bar"));
-    h.set_size(6);
-    t!(h.set_entry_type(EntryType::file()));
-    h.set_cksum();
-    t!(b.append(&h, b"foobar" as &[u8]).await);
+    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    let mut b = Builder::new(bytes);
+    t!(b.append_data("bar", 6, b"foobar" as &[u8]).await);
 
     let contents = t!(b.into_inner().await);
     let mut a = Archive::new(&contents[..]);
@@ -1256,17 +1255,11 @@ async fn long_name_trailing_nul() {
 
 #[tokio::test]
 async fn long_linkname_trailing_nul() {
-    let mut b = Builder::new(Vec::<u8>::new());
-
+    let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'K', 4);
-    append_raw(&mut b, h.as_header(), b"foo\0").await;
-    let mut h = Header::new_ustar();
-
-    t!(h.set_path("bar"));
-    h.set_size(6);
-    t!(h.set_entry_type(EntryType::file()));
-    h.set_cksum();
-    t!(b.append(&h, b"foobar" as &[u8]).await);
+    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    let mut b = Builder::new(bytes);
+    t!(b.append_data("bar", 6, b"foobar" as &[u8]).await);
 
     let contents = t!(b.into_inner().await);
     let mut a = Archive::new(&contents[..]);
@@ -1435,17 +1428,6 @@ async fn path_separators() {
     let short_path: PathBuf = std::iter::repeat_n("abcd", 2).collect();
     let long_path: PathBuf = std::iter::repeat_n("abcd", 50).collect();
 
-    // Make sure UStar headers normalize to Unix path separators
-    let mut header = Header::new_ustar();
-
-    t!(header.set_path(&short_path));
-    assert_eq!(t!(header.path()), short_path);
-    assert!(!header.path_bytes().contains(&b'\\'));
-
-    t!(header.set_path(&long_path));
-    assert_eq!(t!(header.path()), long_path);
-    assert!(!header.path_bytes().contains(&b'\\'));
-
     // Make sure builder output normalizes to Unix path separators,
     // including the PAX fallback used by `append_file`.
     t!(ar
@@ -1560,21 +1542,62 @@ async fn append_path_long_symlink_uses_pax() {
     assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
     assert_eq!(
         &*payload.header().link_name_bytes().unwrap(),
-        b"././@LongSymLink"
+        b"pax-sym-link"
     );
     assert!(entries.next().await.is_none());
 }
 
 #[tokio::test]
-async fn append_link_long_hardlink_uses_pax() {
+#[cfg(unix)]
+async fn append_path_rejects_non_utf8_derived_name_before_writing() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+    let source = td.path().join(OsStr::from_bytes(b"invalid-\xff"));
+
+    let mut ar = Builder::new(Vec::new());
+    assert!(ar.append_path(&source).await.is_err());
+    assert!(ar.get_ref().is_empty());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn append_dir_all_errors_at_invalid_derived_name_after_prior_entry() {
+    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+    let source = td.path().join("source");
+    t!(fs::create_dir(&source).await);
+    t!(File::create(source.join("invalid-\n")).await);
+
+    let mut ar = Builder::new(Vec::new());
+    assert!(ar.append_dir_all("archive", &source).await.is_err());
+    assert!(!ar.get_ref().is_empty());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn append_dir_all_errors_at_invalid_symlink_target_after_prior_entry() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::fs::symlink};
+
+    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+    let source = td.path().join("source");
+    t!(fs::create_dir(&source).await);
+    t!(symlink(
+        OsStr::from_bytes(b"invalid-\xff"),
+        source.join("invalid-link")
+    ));
+
+    let mut ar = Builder::new(Vec::new());
+    ar.follow_symlinks(false);
+    assert!(ar.append_dir_all("archive", &source).await.is_err());
+    assert!(!ar.get_ref().is_empty());
+}
+
+#[tokio::test]
+async fn append_hard_link_long_values_use_pax() {
     let mut ar = Builder::new(Vec::new());
     let archive_path = "hardlink-path".repeat(30);
     let target = "hardlink-target".repeat(20);
-    let mut header = Header::new_ustar();
-    t!(header.set_entry_type(EntryType::Link));
-    header.set_size(0);
-
-    t!(ar.append_link(&mut header, &archive_path, &target).await);
+    t!(ar.append_hard_link(&archive_path, &target).await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -1591,29 +1614,82 @@ async fn append_link_long_hardlink_uses_pax() {
 
     let payload = t!(entries.next().await.unwrap());
     assert!(payload.header().entry_type().is_hard_link());
+    assert_eq!(t!(payload.header().size()), 0);
     assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
     assert_eq!(
         &*payload.header().link_name_bytes().unwrap(),
-        b"././@LongHardLink"
+        b"pax-hard-link"
     );
     assert!(entries.next().await.is_none());
+}
+
+#[tokio::test]
+async fn append_symlink_short_non_ascii_values_use_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let archive_path = "l\u{ed}nk";
+    let target = "targ\u{e9}t";
+    t!(ar.append_symlink(archive_path, target).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert!(pax.header().as_gnu().is_none());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![
+            ("path".to_owned(), archive_path.to_owned()),
+            ("linkpath".to_owned(), target.to_owned()),
+        ]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().as_ustar().is_some());
+    assert!(payload.header().as_gnu().is_none());
+    assert!(payload.header().entry_type().is_symlink());
+    assert_eq!(t!(payload.header().size()), 0);
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+    assert_eq!(
+        &*payload.header().link_name_bytes().unwrap(),
+        b"pax-sym-link"
+    );
+    assert!(entries.next().await.is_none());
+
+    let mut decoded = Archive::new(&contents[..]);
+    let mut entries = t!(decoded.entries());
+    let entry = t!(entries.next().await.unwrap());
+    assert_eq!(&*t!(entry.path_bytes()), archive_path.as_bytes());
+    assert_eq!(&*t!(entry.link_name_bytes()).unwrap(), target.as_bytes());
+}
+
+#[tokio::test]
+async fn append_symlink_rejects_control_values_before_writing() {
+    for (path, target) in [
+        ("link-\t", "target"),
+        ("link", "target-\u{1}"),
+        ("link", "target-\u{85}"),
+    ] {
+        let mut ar = Builder::new(Vec::new());
+        let err = ar.append_symlink(path, target).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Unicode control characters"),
+            "{err}"
+        );
+        assert!(ar.get_ref().is_empty());
+    }
 }
 
 #[tokio::test]
 async fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
-
+    let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'L', 4);
-    append_raw(&mut ar, h.as_header(), b"foo\0").await;
+    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    let mut ar = Builder::new(bytes);
 
-    let mut header = Header::new_ustar();
-    t!(header.set_entry_type(EntryType::Regular));
-    t!(header.set_path("testdir/"));
-    header.set_size(0);
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
+    t!(ar.append_data("testdir/", 0, &mut io::empty()).await);
 
     // Extracting
     let rdr = Cursor::new(t!(ar.into_inner().await));
@@ -1704,9 +1780,7 @@ async fn append_long_multibyte() {
     for _ in 0..512 {
         name.push('a');
         name.push('𑢮');
-        x.append_data(&mut Header::new_ustar(), &name, data)
-            .await
-            .unwrap();
+        x.append_data(&name, 0, data).await.unwrap();
         name.pop();
     }
 }
@@ -1717,20 +1791,11 @@ async fn read_only_directory_containing_files() {
 
     let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_ustar();
-    t!(h.set_path("dir/"));
-    h.set_size(0);
-    t!(h.set_entry_type(EntryType::dir()));
-    h.set_mode(0o444);
-    h.set_cksum();
-    t!(b.append(&h, "".as_bytes()).await);
-
-    let mut h = Header::new_ustar();
-    t!(h.set_path("dir/file"));
-    h.set_size(2);
-    t!(h.set_entry_type(EntryType::file()));
-    h.set_cksum();
-    t!(b.append(&h, "hi".as_bytes()).await);
+    t!(
+        b.append_directory_with_metadata("dir/", EntryMetadata::new().mode(0o444))
+            .await
+    );
+    t!(b.append_data("dir/file", 2, "hi".as_bytes()).await);
 
     let contents = t!(b.into_inner().await);
     let mut ar = Archive::new(&contents[..]);
@@ -1786,12 +1851,9 @@ async fn tar_directory_containing_special_files() {
 #[tokio::test]
 async fn header_size_overflow() {
     // maximal file size doesn't overflow anything
-    let mut ar = Builder::new(Vec::new());
-    let mut header = Header::new_ustar();
-    header.set_size(u64::MAX);
-    header.set_cksum();
-    append_raw(&mut ar, &header, b"x").await;
-    let result = t!(ar.into_inner().await);
+    let mut result = Vec::new();
+    let header = raw_ustar_header(b"overflow", b'0', u64::MAX);
+    append_raw(&mut result, header.as_header(), b"x");
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());
     let entry = e.next().await.unwrap();
@@ -1804,16 +1866,11 @@ async fn header_size_overflow() {
     );
 
     // back-to-back entries that would overflow also don't panic
-    let mut ar = Builder::new(Vec::new());
-    let mut header = Header::new_ustar();
-    header.set_size(1_000);
-    header.set_cksum();
-    t!(ar.append(&header, &[0u8; 1_000][..]).await);
-    let mut header = Header::new_ustar();
-    header.set_size(u64::MAX - 513);
-    header.set_cksum();
-    append_raw(&mut ar, &header, b"x").await;
-    let result = t!(ar.into_inner().await);
+    let mut result = Vec::new();
+    let first_header = raw_ustar_header(b"first", b'0', 1_000);
+    append_raw(&mut result, first_header.as_header(), &[0u8; 1_000]);
+    let header = raw_ustar_header(b"overflow", b'0', u64::MAX - 513);
+    append_raw(&mut result, header.as_header(), b"x");
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());
     let first = e.next().await.unwrap();

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1558,7 +1558,44 @@ async fn append_path_long_symlink_uses_pax() {
     assert!(payload.header().as_gnu().is_none());
     assert!(!payload.header().entry_type().is_gnu_longlink());
     assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert!(payload.header().link_name_bytes().is_none());
+    assert_eq!(
+        &*payload.header().link_name_bytes().unwrap(),
+        b"././@LongSymLink"
+    );
+    assert!(entries.next().await.is_none());
+}
+
+#[tokio::test]
+async fn append_link_long_hardlink_uses_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let archive_path = "hardlink-path".repeat(30);
+    let target = "hardlink-target".repeat(20);
+    let mut header = Header::new_ustar();
+    t!(header.set_entry_type(EntryType::Link));
+    header.set_size(0);
+
+    t!(ar.append_link(&mut header, &archive_path, &target).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![
+            ("path".to_owned(), archive_path),
+            ("linkpath".to_owned(), target),
+        ]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().entry_type().is_hard_link());
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+    assert_eq!(
+        &*payload.header().link_name_bytes().unwrap(),
+        b"././@LongHardLink"
+    );
     assert!(entries.next().await.is_none());
 }
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -15,7 +15,9 @@ use tokio::{
 };
 use tokio_stream::*;
 
-use async_tar::{Archive, ArchiveBuilder, Builder, EntryType, Header};
+use async_tar::{
+    Archive, ArchiveBuilder, Builder, EntryType, GnuHeader, Header, OldHeader, UstarHeader,
+};
 use filetime::FileTime;
 use tempfile::{Builder as TempBuilder, TempDir};
 
@@ -32,6 +34,99 @@ macro_rules! tar {
     ($e:expr) => {
         &include_bytes!(concat!("archives/", $e))[..]
     };
+}
+
+fn old_header() -> OldHeader {
+    let mut header: OldHeader = unsafe { std::mem::zeroed() };
+    header.mtime = *b"00000000000\0";
+    header
+}
+
+fn gnu_header() -> GnuHeader {
+    let mut header: GnuHeader = unsafe { std::mem::zeroed() };
+    header.magic = *b"ustar ";
+    header.version = *b" \0";
+    header.mtime = *b"00000000000\0";
+    header
+}
+
+fn raw_old_header(path: &[u8], entry_type: u8, size: u64) -> OldHeader {
+    let mut header = old_header();
+    header.name[..path.len()].copy_from_slice(path);
+    header.linkflag = [entry_type];
+    encode_octal(&mut header.mode, 0o644);
+    encode_octal(&mut header.uid, 0);
+    encode_octal(&mut header.gid, 0);
+    encode_octal(&mut header.size, size);
+    encode_octal(&mut header.mtime, 0);
+    let cksum = raw_header_checksum(header.as_header());
+    encode_octal(&mut header.cksum, cksum as u64);
+    header
+}
+
+fn raw_ustar_header(path: &[u8], entry_type: u8, size: u64) -> UstarHeader {
+    let mut header: UstarHeader = unsafe { std::mem::zeroed() };
+    header.name[..path.len()].copy_from_slice(path);
+    header.typeflag = [entry_type];
+    header.magic = *b"ustar\0";
+    header.version = *b"00";
+    encode_octal(&mut header.mode, 0o644);
+    encode_octal(&mut header.uid, 0);
+    encode_octal(&mut header.gid, 0);
+    encode_octal(&mut header.size, size);
+    encode_octal(&mut header.mtime, 0);
+    let cksum = raw_header_checksum(header.as_header());
+    encode_octal(&mut header.cksum, cksum as u64);
+    header
+}
+
+fn encode_octal(dst: &mut [u8], value: u64) {
+    let octal = format!("{value:o}");
+    let value = std::iter::once(b'\0').chain(octal.bytes().rev().chain(std::iter::repeat(b'0')));
+    for (slot, value) in dst.iter_mut().rev().zip(value) {
+        *slot = value;
+    }
+}
+
+fn raw_header_checksum(header: &Header) -> u32 {
+    header
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .map(|(offset, byte)| {
+            if (148..156).contains(&offset) {
+                b' ' as u32
+            } else {
+                *byte as u32
+            }
+        })
+        .sum()
+}
+
+async fn append_raw<W: AsyncWrite + Send + Unpin>(
+    builder: &mut Builder<W>,
+    header: &Header,
+    data: &[u8],
+) {
+    t!(builder.get_mut().write_all(header.as_bytes()).await);
+    t!(builder.get_mut().write_all(data).await);
+    let padding = (512 - data.len() % 512) % 512;
+    t!(builder.get_mut().write_all(&vec![0; padding]).await);
+}
+
+async fn pax_records<R: AsyncRead + Unpin>(
+    entry: &mut async_tar::Entry<R>,
+) -> Vec<(String, String)> {
+    let mut records = Vec::new();
+    let mut extensions = t!(entry.pax_extensions().await).unwrap();
+    while let Some(extension) = extensions.next() {
+        let extension = t!(extension);
+        records.push((
+            t!(extension.key()).to_owned(),
+            t!(extension.value()).to_owned(),
+        ));
+    }
+    records
 }
 
 mod header;
@@ -88,7 +183,7 @@ async fn simple_concat() {
 #[tokio::test]
 async fn header_impls() {
     let mut ar = Archive::new(Cursor::new(tar!("simple.tar")));
-    let hn = Header::new_old();
+    let hn = Header::new_ustar();
     let hnb = hn.as_bytes();
     let mut entries = t!(ar.entries());
     while let Some(file) = entries.next().await {
@@ -104,7 +199,7 @@ async fn header_impls() {
 #[tokio::test]
 async fn header_impls_missing_last_header() {
     let mut ar = Archive::new(Cursor::new(tar!("simple_missing_last_header.tar")));
-    let hn = Header::new_old();
+    let hn = Header::new_ustar();
     let hnb = hn.as_bytes();
     let mut entries = t!(ar.entries());
 
@@ -168,6 +263,162 @@ async fn writing_files() {
 }
 
 #[tokio::test]
+async fn builder_append_rejects_non_ustar_writer_headers() {
+    let mut ar = Builder::new(Vec::new());
+
+    let old = old_header();
+    assert!(ar.append(old.as_header(), &[][..]).await.is_err());
+
+    let gnu = gnu_header();
+    assert!(ar.append(gnu.as_header(), &[][..]).await.is_err());
+
+    for entry_type in [
+        EntryType::GNULongName,
+        EntryType::GNULongLink,
+        EntryType::GNUSparse,
+    ] {
+        let mut gnu_extension = Header::new_ustar();
+        t!(gnu_extension.set_path("gnu-extension"));
+        assert!(gnu_extension.set_entry_type(entry_type).is_err());
+        assert_eq!(gnu_extension.entry_type(), EntryType::Regular);
+    }
+    for typeflag in [b'L', b'K', b'S'] {
+        let gnu_extension = raw_ustar_header(b"gnu-extension", typeflag, 0);
+        assert!(ar.append(gnu_extension.as_header(), &[][..]).await.is_err());
+    }
+
+    let unknown_extension = raw_ustar_header(b"unknown-extension", b'Z', 0);
+    assert!(ar
+        .append(unknown_extension.as_header(), &[][..])
+        .await
+        .is_err());
+
+    let mut base256 = Header::new_ustar();
+    t!(base256.set_path("base-256"));
+    base256.set_uid(2_097_152);
+    base256.set_cksum();
+    assert!(ar.append(&base256, &[][..]).await.is_err());
+
+    assert!(ar.get_ref().is_empty());
+}
+
+#[tokio::test]
+async fn append_data_long_path_uses_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let long = "path".repeat(200);
+    let mut header = Header::new_ustar();
+    header.set_size(4);
+
+    t!(ar.append_data(&mut header, &long, "data".as_bytes()).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut ar = Archive::new(&contents[..]);
+    let mut entries = t!(ar.entries_raw());
+
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert!(pax.header().as_ustar().is_some());
+    assert!(pax.header().as_gnu().is_none());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![("path".to_owned(), long.clone())]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().as_ustar().is_some());
+    assert!(payload.header().as_gnu().is_none());
+    assert!(!payload.header().entry_type().is_gnu_longname());
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+}
+
+#[tokio::test]
+async fn append_data_numeric_overflows_use_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let uid = 2_097_152 + 7;
+    let gid = 2_097_152 + 9;
+    let mtime = 8_589_934_592 + 11;
+    let mut header = Header::new_ustar();
+    header.set_size(0);
+    header.set_uid(uid);
+    header.set_gid(gid);
+    header.set_mtime(mtime);
+
+    t!(ar.append_data(&mut header, "overflow", &[][..]).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![
+            ("uid".to_owned(), uid.to_string()),
+            ("gid".to_owned(), gid.to_string()),
+            ("mtime".to_owned(), mtime.to_string()),
+        ]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert_eq!(t!(payload.header().uid()), 0);
+    assert_eq!(t!(payload.header().gid()), 0);
+    assert_eq!(t!(payload.header().mtime()), 0);
+
+    let mut decoded = Archive::new(&contents[..]);
+    let mut entries = t!(decoded.entries());
+    let entry = t!(entries.next().await.unwrap());
+    assert_eq!(t!(entry.header().uid()), uid);
+    assert_eq!(t!(entry.header().gid()), gid);
+    assert_eq!(t!(entry.header().mtime()), mtime);
+}
+
+#[tokio::test]
+async fn append_data_numeric_ustar_limits_do_not_use_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let uid = 2_097_151;
+    let gid = 2_097_151;
+    let mtime = 8_589_934_591;
+    let mut header = Header::new_ustar();
+    header.set_size(0);
+    header.set_uid(uid);
+    header.set_gid(gid);
+    header.set_mtime(mtime);
+
+    t!(ar.append_data(&mut header, "limits", &[][..]).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().entry_type().is_file());
+    assert_eq!(t!(payload.header().uid()), uid);
+    assert_eq!(t!(payload.header().gid()), gid);
+    assert_eq!(t!(payload.header().mtime()), mtime);
+    assert!(entries.next().await.is_none());
+}
+
+#[tokio::test]
+async fn append_data_size_overflow_uses_pax() {
+    let mut ar = Builder::new(Vec::new());
+    let size = 8_589_934_592;
+    let mut header = Header::new_ustar();
+    header.set_size(size);
+
+    t!(ar.append_data(&mut header, "sized", &[][..]).await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![("size".to_owned(), size.to_string())]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert_eq!(t!(payload.header().entry_size()), 0);
+}
+
+#[tokio::test]
 async fn large_filename() {
     let mut ar = Builder::new(Vec::new());
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
@@ -228,7 +479,7 @@ async fn large_filename() {
 async fn large_filename_with_dot_dot_at_100_byte_mark() {
     let mut ar = Builder::new(Vec::new());
 
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
     header.set_mode(0o644);
     header.set_size(4);
 
@@ -552,12 +803,8 @@ async fn unpack_old_style_bsd_dir() {
 
     let mut ar = Builder::new(Vec::new());
 
-    let mut header = Header::new_old();
-    header.set_entry_type(EntryType::Regular);
-    t!(header.set_path("testdir/"));
-    header.set_size(0);
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
+    let header = raw_old_header(b"testdir/", b'0', 0);
+    append_raw(&mut ar, header.as_header(), &[]).await;
 
     // Extracting
     let rdr = Cursor::new(t!(ar.into_inner().await));
@@ -587,7 +834,7 @@ async fn handling_incorrect_file_size() {
     t!(file.write_all(b"").await);
     t!(file.flush().await);
     let mut file = t!(File::open(&path).await);
-    let mut header = Header::new_old();
+    let mut header = Header::new_ustar();
     t!(header.set_path("somepath"));
     header.set_metadata(&t!(file.metadata().await));
     header.set_size(2048); // past the end of file null blocks
@@ -620,17 +867,11 @@ async fn extracting_malicious_tarball() {
     evil_tar = {
         let mut a = Builder::new(evil_tar);
         async fn append<R: AsyncWrite + Send + Unpin>(a: &mut Builder<R>, path: &'static str) {
-            let mut header = Header::new_gnu();
-            assert!(header.set_path(path).is_err(), "was ok: {:?}", path);
-            {
-                let h = header.as_gnu_mut().unwrap();
-                for (a, b) in h.name.iter_mut().zip(path.as_bytes()) {
-                    *a = *b;
-                }
-            }
-            header.set_size(1);
-            header.set_cksum();
-            t!(a.append(&header, io::repeat(1).take(1)).await);
+            let mut validated = Header::new_ustar();
+            assert!(validated.set_path(path).is_err(), "was ok: {:?}", path);
+
+            let header = raw_ustar_header(path.as_bytes(), b'0', 1);
+            t!(a.append(header.as_header(), io::repeat(1).take(1)).await);
         }
 
         append(&mut a, "/tmp/abs_evil.txt").await;
@@ -821,14 +1062,8 @@ async fn backslash_treated_well() {
 
     // Unpack an archive with a backslash in the name
     let mut ar = Builder::new(Vec::<u8>::new());
-    let mut header = Header::new_gnu();
-    header.set_metadata(&t!(fs::metadata(td.path()).await));
-    header.set_size(0);
-    for (a, b) in header.as_old_mut().name.iter_mut().zip(b"foo\\bar\x00") {
-        *a = *b;
-    }
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
+    let header = raw_ustar_header(b"foo\\bar", b'0', 0);
+    t!(ar.append(header.as_header(), &mut io::empty()).await);
     let data = t!(ar.into_inner().await);
     let mut ar = Archive::new(&data[..]);
     let f = t!(t!(ar.entries()).next().await.unwrap());
@@ -997,17 +1232,13 @@ async fn pax_precedence() {
 async fn long_name_trailing_nul() {
     let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'L'));
-    h.set_cksum();
-    t!(b.append(&h, b"foo\0" as &[u8]).await);
-    let mut h = Header::new_gnu();
+    let h = raw_ustar_header(b"././@LongLink", b'L', 4);
+    append_raw(&mut b, h.as_header(), b"foo\0").await;
+    let mut h = Header::new_ustar();
 
     t!(h.set_path("bar"));
     h.set_size(6);
-    h.set_entry_type(EntryType::file());
+    t!(h.set_entry_type(EntryType::file()));
     h.set_cksum();
     t!(b.append(&h, b"foobar" as &[u8]).await);
 
@@ -1022,17 +1253,13 @@ async fn long_name_trailing_nul() {
 async fn long_linkname_trailing_nul() {
     let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'K'));
-    h.set_cksum();
-    t!(b.append(&h, b"foo\0" as &[u8]).await);
-    let mut h = Header::new_gnu();
+    let h = raw_ustar_header(b"././@LongLink", b'K', 4);
+    append_raw(&mut b, h.as_header(), b"foo\0").await;
+    let mut h = Header::new_ustar();
 
     t!(h.set_path("bar"));
     h.set_size(6);
-    h.set_entry_type(EntryType::file());
+    t!(h.set_entry_type(EntryType::file()));
     h.set_cksum();
     t!(b.append(&h, b"foobar" as &[u8]).await);
 
@@ -1044,7 +1271,7 @@ async fn long_linkname_trailing_nul() {
 }
 
 #[tokio::test]
-async fn encoded_long_name_has_trailing_nul() {
+async fn encoded_long_name_uses_pax() {
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
     let path = td.path().join("foo");
     t!(t!(File::create(&path).await).write_all(b"test").await);
@@ -1060,10 +1287,11 @@ async fn encoded_long_name_has_trailing_nul() {
     let mut e = t!(t!(a.entries_raw()).next().await.unwrap());
     let mut name = Vec::new();
     t!(e.read_to_end(&mut name).await);
-    assert_eq!(name[name.len() - 1], 0);
-
-    let header_name = &e.header().as_gnu().unwrap().name;
-    assert!(header_name.starts_with(b"././@LongLink\x00"));
+    assert!(e.header().as_ustar().is_some());
+    assert!(e.header().as_gnu().is_none());
+    assert!(e.header().entry_type().is_pax_local_extensions());
+    assert!(name.starts_with(b"810 path="));
+    assert_eq!(name[name.len() - 1], b'\n');
 }
 
 #[tokio::test]
@@ -1213,8 +1441,8 @@ async fn path_separators() {
     assert_eq!(t!(header.path()), long_path);
     assert!(!header.path_bytes().contains(&b'\\'));
 
-    // Make sure GNU headers normalize to Unix path separators,
-    // including the `@LongLink` fallback used by `append_file`.
+    // Make sure builder output normalizes to Unix path separators,
+    // including the PAX fallback used by `append_file`.
     t!(ar
         .append_file(&short_path, &mut t!(File::open(&path).await))
         .await);
@@ -1291,20 +1519,49 @@ async fn append_path_symlink() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
+async fn append_path_long_symlink_uses_pax() {
+    use std::os::unix::fs::symlink;
+
+    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+    let source = td.path().join("source");
+    let target = "link-target".repeat(20);
+    t!(symlink(&target, &source));
+
+    let mut ar = Builder::new(Vec::new());
+    ar.follow_symlinks(false);
+    t!(ar.append_path_with_name(&source, "symlink").await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert!(pax.header().as_ustar().is_some());
+    assert!(pax.header().as_gnu().is_none());
+    assert_eq!(
+        pax_records(&mut pax).await,
+        vec![("linkpath".to_owned(), target)]
+    );
+
+    let payload = t!(entries.next().await.unwrap());
+    assert!(payload.header().as_ustar().is_some());
+    assert!(payload.header().as_gnu().is_none());
+    assert!(!payload.header().entry_type().is_gnu_longlink());
+    assert!(payload.header().link_name_bytes().is_none());
+}
+
+#[tokio::test]
 async fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
     let mut ar = Builder::new(Vec::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'L'));
-    h.set_cksum();
-    t!(ar.append(&h, b"foo\0" as &[u8]).await);
+    let h = raw_ustar_header(b"././@LongLink", b'L', 4);
+    append_raw(&mut ar, h.as_header(), b"foo\0").await;
 
-    let mut header = Header::new_gnu();
-    header.set_entry_type(EntryType::Regular);
+    let mut header = Header::new_ustar();
+    t!(header.set_entry_type(EntryType::Regular));
     t!(header.set_path("testdir/"));
     header.set_size(0);
     header.set_cksum();
@@ -1399,7 +1656,7 @@ async fn append_long_multibyte() {
     for _ in 0..512 {
         name.push('a');
         name.push('𑢮');
-        x.append_data(&mut Header::new_gnu(), &name, data)
+        x.append_data(&mut Header::new_ustar(), &name, data)
             .await
             .unwrap();
         name.pop();
@@ -1412,18 +1669,18 @@ async fn read_only_directory_containing_files() {
 
     let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_gnu();
+    let mut h = Header::new_ustar();
     t!(h.set_path("dir/"));
     h.set_size(0);
-    h.set_entry_type(EntryType::dir());
+    t!(h.set_entry_type(EntryType::dir()));
     h.set_mode(0o444);
     h.set_cksum();
     t!(b.append(&h, "".as_bytes()).await);
 
-    let mut h = Header::new_gnu();
+    let mut h = Header::new_ustar();
     t!(h.set_path("dir/file"));
     h.set_size(2);
-    h.set_entry_type(EntryType::file());
+    t!(h.set_entry_type(EntryType::file()));
     h.set_cksum();
     t!(b.append(&h, "hi".as_bytes()).await);
 
@@ -1466,10 +1723,10 @@ async fn tar_directory_containing_special_files() {
 async fn header_size_overflow() {
     // maximal file size doesn't overflow anything
     let mut ar = Builder::new(Vec::new());
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
     header.set_size(u64::MAX);
     header.set_cksum();
-    t!(ar.append(&header, "x".as_bytes()).await);
+    append_raw(&mut ar, &header, b"x").await;
     let result = t!(ar.into_inner().await);
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());
@@ -1484,14 +1741,14 @@ async fn header_size_overflow() {
 
     // back-to-back entries that would overflow also don't panic
     let mut ar = Builder::new(Vec::new());
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
     header.set_size(1_000);
     header.set_cksum();
     t!(ar.append(&header, &[0u8; 1_000][..]).await);
-    let mut header = Header::new_gnu();
+    let mut header = Header::new_ustar();
     header.set_size(u64::MAX - 513);
     header.set_cksum();
-    t!(ar.append(&header, "x".as_bytes()).await);
+    append_raw(&mut ar, &header, b"x").await;
     let result = t!(ar.into_inner().await);
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -118,8 +118,8 @@ async fn pax_records<R: AsyncRead + Unpin>(
     entry: &mut async_tar::Entry<R>,
 ) -> Vec<(String, String)> {
     let mut records = Vec::new();
-    let mut extensions = t!(entry.pax_extensions().await).unwrap();
-    while let Some(extension) = extensions.next() {
+    let extensions = t!(entry.pax_extensions().await).unwrap();
+    for extension in extensions {
         let extension = t!(extension);
         records.push((
             t!(extension.key()).to_owned(),

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 use tokio_stream::*;
 
-use async_tar::{Archive, ArchiveBuilder, Builder, EntryMetadata, Header, OldHeader, UstarHeader};
+use async_tar::{Archive, ArchiveBuilder, Builder, EntryMetadata, EntryType, Header};
 use filetime::FileTime;
 use tempfile::{Builder as TempBuilder, TempDir};
 
@@ -34,75 +34,23 @@ macro_rules! tar {
     };
 }
 
-fn old_header() -> OldHeader {
-    let mut header: OldHeader = unsafe { std::mem::zeroed() };
-    header.mtime = *b"00000000000\0";
+fn raw_header(mut header: Header, path: &[u8], entry_type: u8, size: u64) -> Header {
+    header.as_old_mut().name[..path.len()].copy_from_slice(path);
+    header.set_entry_type(EntryType::new(entry_type));
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_size(size);
+    header.set_cksum();
     header
 }
 
-fn raw_old_header(path: &[u8], entry_type: u8, size: u64) -> OldHeader {
-    let mut header = old_header();
-    header.name[..path.len()].copy_from_slice(path);
-    header.linkflag = [entry_type];
-    encode_octal(&mut header.mode, 0o644);
-    encode_octal(&mut header.uid, 0);
-    encode_octal(&mut header.gid, 0);
-    encode_numeric(&mut header.size, size);
-    encode_octal(&mut header.mtime, 0);
-    let cksum = raw_header_checksum(header.as_header());
-    encode_octal(&mut header.cksum, cksum as u64);
-    header
+fn raw_old_header(path: &[u8], entry_type: u8, size: u64) -> Header {
+    raw_header(Header::new_old(), path, entry_type, size)
 }
 
-fn raw_ustar_header(path: &[u8], entry_type: u8, size: u64) -> UstarHeader {
-    let mut header: UstarHeader = unsafe { std::mem::zeroed() };
-    header.name[..path.len()].copy_from_slice(path);
-    header.typeflag = [entry_type];
-    header.magic = *b"ustar\0";
-    header.version = *b"00";
-    encode_octal(&mut header.mode, 0o644);
-    encode_octal(&mut header.uid, 0);
-    encode_octal(&mut header.gid, 0);
-    encode_numeric(&mut header.size, size);
-    encode_octal(&mut header.mtime, 0);
-    let cksum = raw_header_checksum(header.as_header());
-    encode_octal(&mut header.cksum, cksum as u64);
-    header
-}
-
-fn encode_octal(dst: &mut [u8], value: u64) {
-    let octal = format!("{value:o}");
-    let value = std::iter::once(b'\0').chain(octal.bytes().rev().chain(std::iter::repeat(b'0')));
-    for (slot, value) in dst.iter_mut().rev().zip(value) {
-        *slot = value;
-    }
-}
-
-fn encode_numeric(dst: &mut [u8], value: u64) {
-    if value < 8_589_934_592 {
-        encode_octal(dst, value);
-        return;
-    }
-
-    dst.fill(0);
-    let offset = dst.len() - std::mem::size_of::<u64>();
-    dst[offset..].copy_from_slice(&value.to_be_bytes());
-    dst[0] |= 0x80;
-}
-
-fn raw_header_checksum(header: &Header) -> u32 {
-    header
-        .as_bytes()
-        .iter()
-        .enumerate()
-        .map(|(offset, byte)| {
-            if (148..156).contains(&offset) {
-                b' ' as u32
-            } else {
-                *byte as u32
-            }
-        })
-        .sum()
+fn raw_ustar_header(path: &[u8], entry_type: u8, size: u64) -> Header {
+    raw_header(Header::new_ustar(), path, entry_type, size)
 }
 
 fn append_raw(bytes: &mut Vec<u8>, header: &Header, data: &[u8]) {
@@ -112,19 +60,27 @@ fn append_raw(bytes: &mut Vec<u8>, header: &Header, data: &[u8]) {
     bytes.extend_from_slice(&vec![0; padding]);
 }
 
-async fn pax_records<R: AsyncRead + Unpin>(
-    entry: &mut async_tar::Entry<R>,
-) -> Vec<(String, String)> {
+async fn pax_payload(contents: &[u8], payload_path: &[u8]) -> (Vec<(String, String)>, Header) {
+    let mut raw = Archive::new(contents);
+    let mut entries = t!(raw.entries_raw());
+    let mut pax = t!(entries.next().await.unwrap());
+    assert!(pax.header().entry_type().is_pax_local_extensions());
+    assert!(pax.header().as_ustar().is_some());
+    assert!(pax.header().as_gnu().is_none());
     let mut records = Vec::new();
-    let extensions = t!(entry.pax_extensions().await).unwrap();
-    for extension in extensions {
+    for extension in t!(pax.pax_extensions().await).unwrap() {
         let extension = t!(extension);
         records.push((
             t!(extension.key()).to_owned(),
             t!(extension.value()).to_owned(),
         ));
     }
-    records
+    let payload = t!(entries.next().await.unwrap()).header().clone();
+    assert!(payload.as_ustar().is_some());
+    assert!(payload.as_gnu().is_none());
+    assert_eq!(&*payload.path_bytes(), payload_path);
+    assert!(entries.next().await.is_none());
+    (records, payload)
 }
 
 mod header;
@@ -181,7 +137,8 @@ async fn simple_concat() {
 #[tokio::test]
 async fn header_impls() {
     let mut ar = Archive::new(Cursor::new(tar!("simple.tar")));
-    let hnb = [0; 512];
+    let hn = Header::new_old();
+    let hnb = hn.as_bytes();
     let mut entries = t!(ar.entries());
     while let Some(file) = entries.next().await {
         let file = t!(file);
@@ -196,7 +153,8 @@ async fn header_impls() {
 #[tokio::test]
 async fn header_impls_missing_last_header() {
     let mut ar = Archive::new(Cursor::new(tar!("simple_missing_last_header.tar")));
-    let hnb = [0; 512];
+    let hn = Header::new_old();
+    let hnb = hn.as_bytes();
     let mut entries = t!(ar.entries());
 
     while let Some(file) = entries.next().await {
@@ -266,23 +224,9 @@ async fn append_data_long_path_uses_pax() {
     t!(ar.append_data(&long, 4, "data".as_bytes()).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut ar = Archive::new(&contents[..]);
-    let mut entries = t!(ar.entries_raw());
-
-    let mut pax = t!(entries.next().await.unwrap());
-    assert!(pax.header().entry_type().is_pax_local_extensions());
-    assert!(pax.header().as_ustar().is_some());
-    assert!(pax.header().as_gnu().is_none());
-    assert_eq!(
-        pax_records(&mut pax).await,
-        vec![("path".to_owned(), long.clone())]
-    );
-
-    let payload = t!(entries.next().await.unwrap());
-    assert!(payload.header().as_ustar().is_some());
-    assert!(payload.header().as_gnu().is_none());
-    assert!(!payload.header().entry_type().is_gnu_longname());
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+    let (records, payload) = pax_payload(&contents, b"pax-entry").await;
+    assert_eq!(records, vec![("path".to_owned(), long.clone())]);
+    assert!(!payload.entry_type().is_gnu_longname());
 }
 
 #[tokio::test]
@@ -293,20 +237,8 @@ async fn append_data_short_non_ascii_path_uses_pax() {
     t!(ar.append_data(path, 0, &[][..]).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
-    assert!(pax.header().entry_type().is_pax_local_extensions());
-    assert_eq!(
-        pax_records(&mut pax).await,
-        vec![("path".to_owned(), path.to_owned())]
-    );
-
-    let payload = t!(entries.next().await.unwrap());
-    assert!(payload.header().as_ustar().is_some());
-    assert!(payload.header().as_gnu().is_none());
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert!(entries.next().await.is_none());
+    let (records, _) = pax_payload(&contents, b"pax-entry").await;
+    assert_eq!(records, vec![("path".to_owned(), path.to_owned())]);
 
     let mut decoded = Archive::new(&contents[..]);
     let mut entries = t!(decoded.entries());
@@ -347,11 +279,9 @@ async fn append_data_numeric_overflows_use_pax() {
         .await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
+    let (records, payload) = pax_payload(&contents, b"pax-entry").await;
     assert_eq!(
-        pax_records(&mut pax).await,
+        records,
         vec![
             ("path".to_owned(), path.clone()),
             ("uid".to_owned(), uid.to_string()),
@@ -360,12 +290,9 @@ async fn append_data_numeric_overflows_use_pax() {
         ]
     );
 
-    let payload = t!(entries.next().await.unwrap());
-    assert_eq!(t!(payload.header().uid()), 0);
-    assert_eq!(t!(payload.header().gid()), 0);
-    assert_eq!(t!(payload.header().mtime()), 0);
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert!(entries.next().await.is_none());
+    assert_eq!(t!(payload.uid()), 0);
+    assert_eq!(t!(payload.gid()), 0);
+    assert_eq!(t!(payload.mtime()), 0);
 
     let mut decoded = Archive::new(&contents[..]);
     let mut entries = t!(decoded.entries());
@@ -407,16 +334,9 @@ async fn append_data_size_overflow_uses_pax() {
     t!(ar.append_data("sized", size, &[][..]).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
-    assert_eq!(
-        pax_records(&mut pax).await,
-        vec![("size".to_owned(), size.to_string())]
-    );
-
-    let payload = t!(entries.next().await.unwrap());
-    assert_eq!(t!(payload.header().entry_size()), 0);
+    let (records, payload) = pax_payload(&contents, b"sized").await;
+    assert_eq!(records, vec![("size".to_owned(), size.to_string())]);
+    assert_eq!(t!(payload.entry_size()), 0);
 }
 
 #[tokio::test]
@@ -760,7 +680,7 @@ async fn append_dir_all_blank_dest() {
     t!(file2.flush().await);
 
     let mut ar = Builder::new(Vec::new());
-    t!(ar.append_dir_all_at_root(base_dir).await);
+    t!(ar.append_dir_all("", base_dir).await);
     let data = t!(ar.into_inner().await);
 
     let mut ar = Archive::new(Cursor::new(data));
@@ -820,7 +740,7 @@ async fn unpack_old_style_bsd_dir() {
 
     let mut bytes = Vec::new();
     let header = raw_old_header(b"testdir/", b'0', 0);
-    append_raw(&mut bytes, header.as_header(), &[]);
+    append_raw(&mut bytes, &header, &[]);
     bytes.extend_from_slice(&[0; 1024]);
 
     // Extracting
@@ -879,7 +799,7 @@ async fn extracting_malicious_tarball() {
     evil_tar = {
         fn append(a: &mut Vec<u8>, path: &'static str) {
             let header = raw_ustar_header(path.as_bytes(), b'0', 1);
-            append_raw(a, header.as_header(), &[1]);
+            append_raw(a, &header, &[1]);
         }
 
         append(&mut evil_tar, "/tmp/abs_evil.txt");
@@ -1070,7 +990,7 @@ async fn backslash_treated_well() {
     // Unpack an archive with a backslash in the name
     let mut data = Vec::new();
     let header = raw_ustar_header(b"foo\\bar", b'0', 0);
-    append_raw(&mut data, header.as_header(), &[]);
+    append_raw(&mut data, &header, &[]);
     data.extend_from_slice(&[0; 1024]);
     let mut ar = Archive::new(&data[..]);
     let f = t!(t!(ar.entries()).next().await.unwrap());
@@ -1089,10 +1009,7 @@ async fn nul_bytes_in_path() {
     let nul_path = OsStr::from_bytes(b"foo\0");
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
     let mut ar = Builder::new(Vec::<u8>::new());
-    let err = ar
-        .append_dir(Path::new(nul_path), td.path())
-        .await
-        .unwrap_err();
+    let err = ar.append_dir(nul_path, td.path()).await.unwrap_err();
     assert!(err.to_string().contains("Unicode control characters"));
 }
 
@@ -1242,7 +1159,7 @@ async fn pax_precedence() {
 async fn long_name_trailing_nul() {
     let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'L', 4);
-    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    append_raw(&mut bytes, &h, b"foo\0");
     let mut b = Builder::new(bytes);
     t!(b.append_data("bar", 6, b"foobar" as &[u8]).await);
 
@@ -1257,7 +1174,7 @@ async fn long_name_trailing_nul() {
 async fn long_linkname_trailing_nul() {
     let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'K', 4);
-    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    append_raw(&mut bytes, &h, b"foo\0");
     let mut b = Builder::new(bytes);
     t!(b.append_data("bar", 6, b"foobar" as &[u8]).await);
 
@@ -1521,30 +1438,17 @@ async fn append_path_long_symlink_uses_pax() {
     t!(ar.append_path_with_name(&source, &archive_path).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
-    assert!(pax.header().entry_type().is_pax_local_extensions());
-    assert!(pax.header().as_ustar().is_some());
-    assert!(pax.header().as_gnu().is_none());
+    let (records, payload) = pax_payload(&contents, b"pax-entry").await;
     assert_eq!(
-        pax_records(&mut pax).await,
+        records,
         vec![
             ("path".to_owned(), archive_path),
             ("linkpath".to_owned(), target),
         ]
     );
 
-    let payload = t!(entries.next().await.unwrap());
-    assert!(payload.header().as_ustar().is_some());
-    assert!(payload.header().as_gnu().is_none());
-    assert!(!payload.header().entry_type().is_gnu_longlink());
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert_eq!(
-        &*payload.header().link_name_bytes().unwrap(),
-        b"pax-sym-link"
-    );
-    assert!(entries.next().await.is_none());
+    assert!(!payload.entry_type().is_gnu_longlink());
+    assert_eq!(&*payload.link_name_bytes().unwrap(), b"pax-sym-link");
 }
 
 #[tokio::test]
@@ -1600,27 +1504,18 @@ async fn append_hard_link_long_values_use_pax() {
     t!(ar.append_hard_link(&archive_path, &target).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
-    assert!(pax.header().entry_type().is_pax_local_extensions());
+    let (records, payload) = pax_payload(&contents, b"pax-entry").await;
     assert_eq!(
-        pax_records(&mut pax).await,
+        records,
         vec![
             ("path".to_owned(), archive_path),
             ("linkpath".to_owned(), target),
         ]
     );
 
-    let payload = t!(entries.next().await.unwrap());
-    assert!(payload.header().entry_type().is_hard_link());
-    assert_eq!(t!(payload.header().size()), 0);
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert_eq!(
-        &*payload.header().link_name_bytes().unwrap(),
-        b"pax-hard-link"
-    );
-    assert!(entries.next().await.is_none());
+    assert!(payload.entry_type().is_hard_link());
+    assert_eq!(t!(payload.size()), 0);
+    assert_eq!(&*payload.link_name_bytes().unwrap(), b"pax-hard-link");
 }
 
 #[tokio::test]
@@ -1631,30 +1526,18 @@ async fn append_symlink_short_non_ascii_values_use_pax() {
     t!(ar.append_symlink(archive_path, target).await);
 
     let contents = t!(ar.into_inner().await);
-    let mut raw = Archive::new(&contents[..]);
-    let mut entries = t!(raw.entries_raw());
-    let mut pax = t!(entries.next().await.unwrap());
-    assert!(pax.header().entry_type().is_pax_local_extensions());
-    assert!(pax.header().as_gnu().is_none());
+    let (records, payload) = pax_payload(&contents, b"pax-entry").await;
     assert_eq!(
-        pax_records(&mut pax).await,
+        records,
         vec![
             ("path".to_owned(), archive_path.to_owned()),
             ("linkpath".to_owned(), target.to_owned()),
         ]
     );
 
-    let payload = t!(entries.next().await.unwrap());
-    assert!(payload.header().as_ustar().is_some());
-    assert!(payload.header().as_gnu().is_none());
-    assert!(payload.header().entry_type().is_symlink());
-    assert_eq!(t!(payload.header().size()), 0);
-    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
-    assert_eq!(
-        &*payload.header().link_name_bytes().unwrap(),
-        b"pax-sym-link"
-    );
-    assert!(entries.next().await.is_none());
+    assert!(payload.entry_type().is_symlink());
+    assert_eq!(t!(payload.size()), 0);
+    assert_eq!(&*payload.link_name_bytes().unwrap(), b"pax-sym-link");
 
     let mut decoded = Archive::new(&contents[..]);
     let mut entries = t!(decoded.entries());
@@ -1686,7 +1569,7 @@ async fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
 
     let mut bytes = Vec::new();
     let h = raw_ustar_header(b"././@LongLink", b'L', 4);
-    append_raw(&mut bytes, h.as_header(), b"foo\0");
+    append_raw(&mut bytes, &h, b"foo\0");
     let mut ar = Builder::new(bytes);
 
     t!(ar.append_data("testdir/", 0, &mut io::empty()).await);
@@ -1853,7 +1736,7 @@ async fn header_size_overflow() {
     // maximal file size doesn't overflow anything
     let mut result = Vec::new();
     let header = raw_ustar_header(b"overflow", b'0', u64::MAX);
-    append_raw(&mut result, header.as_header(), b"x");
+    append_raw(&mut result, &header, b"x");
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());
     let entry = e.next().await.unwrap();
@@ -1868,9 +1751,9 @@ async fn header_size_overflow() {
     // back-to-back entries that would overflow also don't panic
     let mut result = Vec::new();
     let first_header = raw_ustar_header(b"first", b'0', 1_000);
-    append_raw(&mut result, first_header.as_header(), &[0u8; 1_000]);
+    append_raw(&mut result, &first_header, &[0u8; 1_000]);
     let header = raw_ustar_header(b"overflow", b'0', u64::MAX - 513);
-    append_raw(&mut result, header.as_header(), b"x");
+    append_raw(&mut result, &header, b"x");
     let mut ar = Archive::new(&result[..]);
     let mut e = t!(ar.entries());
     let first = e.next().await.unwrap();

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -16,7 +16,6 @@ use tokio::{
 use tokio_stream::*;
 
 use async_tar::{Archive, ArchiveBuilder, Builder, EntryMetadata, EntryType, Header};
-use filetime::FileTime;
 use tempfile::{Builder as TempBuilder, TempDir};
 
 macro_rules! t {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -334,6 +334,7 @@ async fn append_data_long_path_uses_pax() {
 #[tokio::test]
 async fn append_data_numeric_overflows_use_pax() {
     let mut ar = Builder::new(Vec::new());
+    let path = "numeric-overflow-path".repeat(30);
     let uid = 2_097_152 + 7;
     let gid = 2_097_152 + 9;
     let mtime = 8_589_934_592 + 11;
@@ -343,7 +344,7 @@ async fn append_data_numeric_overflows_use_pax() {
     header.set_gid(gid);
     header.set_mtime(mtime);
 
-    t!(ar.append_data(&mut header, "overflow", &[][..]).await);
+    t!(ar.append_data(&mut header, &path, &[][..]).await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -352,6 +353,7 @@ async fn append_data_numeric_overflows_use_pax() {
     assert_eq!(
         pax_records(&mut pax).await,
         vec![
+            ("path".to_owned(), path.clone()),
             ("uid".to_owned(), uid.to_string()),
             ("gid".to_owned(), gid.to_string()),
             ("mtime".to_owned(), mtime.to_string()),
@@ -362,10 +364,13 @@ async fn append_data_numeric_overflows_use_pax() {
     assert_eq!(t!(payload.header().uid()), 0);
     assert_eq!(t!(payload.header().gid()), 0);
     assert_eq!(t!(payload.header().mtime()), 0);
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
+    assert!(entries.next().await.is_none());
 
     let mut decoded = Archive::new(&contents[..]);
     let mut entries = t!(decoded.entries());
     let entry = t!(entries.next().await.unwrap());
+    assert_eq!(&*t!(entry.path_bytes()), path.as_bytes());
     assert_eq!(t!(entry.header().uid()), uid);
     assert_eq!(t!(entry.header().gid()), gid);
     assert_eq!(t!(entry.header().mtime()), mtime);
@@ -1525,12 +1530,13 @@ async fn append_path_long_symlink_uses_pax() {
 
     let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
     let source = td.path().join("source");
+    let archive_path = "symlink-path".repeat(30);
     let target = "link-target".repeat(20);
     t!(symlink(&target, &source));
 
     let mut ar = Builder::new(Vec::new());
     ar.follow_symlinks(false);
-    t!(ar.append_path_with_name(&source, "symlink").await);
+    t!(ar.append_path_with_name(&source, &archive_path).await);
 
     let contents = t!(ar.into_inner().await);
     let mut raw = Archive::new(&contents[..]);
@@ -1541,14 +1547,19 @@ async fn append_path_long_symlink_uses_pax() {
     assert!(pax.header().as_gnu().is_none());
     assert_eq!(
         pax_records(&mut pax).await,
-        vec![("linkpath".to_owned(), target)]
+        vec![
+            ("path".to_owned(), archive_path),
+            ("linkpath".to_owned(), target),
+        ]
     );
 
     let payload = t!(entries.next().await.unwrap());
     assert!(payload.header().as_ustar().is_some());
     assert!(payload.header().as_gnu().is_none());
     assert!(!payload.header().entry_type().is_gnu_longlink());
+    assert_eq!(&*payload.header().path_bytes(), b"pax-entry");
     assert!(payload.header().link_name_bytes().is_none());
+    assert!(entries.next().await.is_none());
 }
 
 #[tokio::test]
@@ -1716,7 +1727,23 @@ async fn tar_directory_containing_special_files() {
     t!(env::set_current_dir("/dev/"));
     // CI systems seem to have issues with creating a chr device
     t!(ar.append_path("null").await);
-    t!(ar.finish().await);
+
+    let contents = t!(ar.into_inner().await);
+    let mut raw = Archive::new(&contents[..]);
+    let mut entries = t!(raw.entries_raw());
+    let mut entry_count = 0;
+    while let Some(entry) = entries.next().await {
+        let entry = t!(entry);
+        let header = entry.header();
+        let entry_type = header.entry_type();
+        assert!(header.as_ustar().is_some());
+        assert!(header.as_gnu().is_none());
+        assert!(!entry_type.is_gnu_longname());
+        assert!(!entry_type.is_gnu_longlink());
+        assert!(!entry_type.is_gnu_sparse());
+        entry_count += 1;
+    }
+    assert!(entry_count >= 3);
 }
 
 #[tokio::test]

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -18,17 +18,66 @@ macro_rules! t {
     };
 }
 
+fn raw_header(
+    path: &[u8],
+    target: Option<&[u8]>,
+    typeflag: u8,
+    size: u64,
+    mode: u32,
+) -> async_tar::UstarHeader {
+    let mut header: async_tar::UstarHeader = unsafe { std::mem::zeroed() };
+    header.name[..path.len()].copy_from_slice(path);
+    if let Some(target) = target {
+        header.linkname[..target.len()].copy_from_slice(target);
+    }
+    header.typeflag = [typeflag];
+    header.magic = *b"ustar\0";
+    header.version = *b"00";
+    encode_octal(&mut header.mode, mode as u64);
+    encode_octal(&mut header.uid, 0);
+    encode_octal(&mut header.gid, 0);
+    encode_octal(&mut header.size, size);
+    encode_octal(&mut header.mtime, 0);
+    let checksum = header
+        .as_header()
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .map(|(offset, byte)| {
+            if (148..156).contains(&offset) {
+                b' ' as u32
+            } else {
+                *byte as u32
+            }
+        })
+        .sum::<u32>();
+    encode_octal(&mut header.cksum, checksum as u64);
+    header
+}
+
+fn raw_link_header(path: &[u8], target: &[u8]) -> async_tar::UstarHeader {
+    raw_header(path, Some(target), b'1', 0, 0o644)
+}
+
+fn encode_octal(dst: &mut [u8], value: u64) {
+    let octal = format!("{value:o}");
+    let value = std::iter::once(b'\0').chain(octal.bytes().rev().chain(std::iter::repeat(b'0')));
+    for (slot, value) in dst.iter_mut().rev().zip(value) {
+        *slot = value;
+    }
+}
+
+fn append_raw(bytes: &mut Vec<u8>, header: &async_tar::Header, data: &[u8]) {
+    bytes.extend_from_slice(header.as_bytes());
+    bytes.extend_from_slice(data);
+    let padding = (512 - data.len() % 512) % 512;
+    bytes.extend_from_slice(&vec![0; padding]);
+}
+
 #[tokio::test]
 async fn absolute_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "/bar").await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -47,25 +96,16 @@ async fn absolute_symlink() {
 #[tokio::test]
 async fn absolute_hardlink() {
     let td = t!(Builder::new().prefix("tar").tempdir());
-    let mut ar = async_tar::Builder::new(Vec::new());
+    let mut bytes = Vec::new();
+    let file_header = raw_header(b"foo", None, b'0', 0, 0o644);
+    append_raw(&mut bytes, file_header.as_header(), &[]);
 
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Link));
-    t!(header.set_path("bar"));
     // This absolute path under tempdir will be created at unpack time
-    t!(header.set_link_name(td.path().join("foo")));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    let target = td.path().join("foo");
+    let header = raw_link_header(b"bar", target.to_str().unwrap().as_bytes());
+    append_raw(&mut bytes, header.as_header(), &[]);
+    bytes.extend_from_slice(&[0; 1024]);
 
-    let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
 
     t!(ar.unpack(td.path()).await);
@@ -76,21 +116,8 @@ async fn absolute_hardlink() {
 #[tokio::test]
 async fn relative_hardlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Link));
-    t!(header.set_path("bar"));
-    t!(header.set_link_name("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_data("foo", 0, &[][..]).await);
+    t!(ar.append_hard_link("bar", "foo").await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -104,21 +131,8 @@ async fn relative_hardlink() {
 #[tokio::test]
 async fn absolute_link_deref_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("/"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "/").await);
+    t!(ar.append_data("foo/bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -132,21 +146,8 @@ async fn absolute_link_deref_error() {
 #[tokio::test]
 async fn relative_link_deref_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../../../../"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "../../../../").await);
+    t!(ar.append_data("foo/bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -163,14 +164,9 @@ async fn directory_permissions_are_cleared() {
     use ::std::os::unix::fs::PermissionsExt;
 
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Directory));
-    t!(header.set_path("foo"));
-    header.set_mode(0o777);
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar
+        .append_directory_with_metadata("foo", async_tar::EntryMetadata::new().mode(0o777))
+        .await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -197,28 +193,9 @@ async fn directory_permissions_are_cleared() {
 #[cfg(not(windows))] // dangling symlinks have weird permissions
 async fn modify_link_just_created() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("bar/foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "bar").await);
+    t!(ar.append_data("bar/foo", 0, &[][..]).await);
+    t!(ar.append_data("foo/bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -236,21 +213,8 @@ async fn modify_link_just_created() {
 #[cfg(not(windows))] // dangling symlinks have weird permissions
 async fn modify_outside_with_relative_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("symlink"));
-    t!(header.set_link_name(".."));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("symlink/foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("symlink", "..").await);
+    t!(ar.append_data("symlink/foo/bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -264,21 +228,8 @@ async fn modify_outside_with_relative_symlink() {
 #[tokio::test]
 async fn parent_paths_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name(".."));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "..").await);
+    t!(ar.append_data("foo/bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -294,21 +245,13 @@ async fn parent_paths_error() {
 async fn good_parent_paths_ok() {
     use std::path::PathBuf;
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path(PathBuf::from("foo").join("bar")));
-    t!(header.set_link_name(PathBuf::from("..").join("bar")));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar
+        .append_symlink(
+            PathBuf::from("foo").join("bar"),
+            PathBuf::from("..").join("bar")
+        )
+        .await);
+    t!(ar.append_data("bar", 0, &[][..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -322,22 +265,12 @@ async fn good_parent_paths_ok() {
 
 #[tokio::test]
 async fn modify_hard_link_just_created() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+    let mut bytes = Vec::new();
+    let header = raw_link_header(b"foo", b"../test");
+    append_raw(&mut bytes, header.as_header(), &[]);
+    let mut ar = async_tar::Builder::new(bytes);
 
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Link));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../test"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(1);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &b"x"[..]).await);
+    t!(ar.append_data("foo", 1, &b"x"[..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -358,21 +291,8 @@ async fn modify_hard_link_just_created() {
 #[tokio::test]
 async fn modify_symlink_just_created() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../test"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(1);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &b"x"[..]).await);
+    t!(ar.append_symlink("foo", "../test").await);
+    t!(ar.append_data("foo", 1, &b"x"[..]).await);
 
     let bytes = t!(ar.into_inner().await);
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -393,14 +313,7 @@ async fn modify_symlink_just_created() {
 #[tokio::test]
 async fn deny_absolute_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "/bar").await);
 
     let bytes = t!(ar.into_inner().await);
 
@@ -414,14 +327,7 @@ async fn deny_absolute_symlink() {
 #[tokio::test]
 async fn deny_relative_link() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../../../../"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", "../../../../").await);
 
     let bytes = t!(ar.into_inner().await);
 
@@ -436,21 +342,8 @@ async fn deny_relative_link() {
 #[cfg(unix)]
 async fn accept_relative_link() {
     let mut ar = async_tar::Builder::new(Vec::new());
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo/bar"));
-    t!(header.set_link_name("../baz"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(1);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("baz"));
-    header.set_cksum();
-    t!(ar.append(&header, &b"x"[..]).await);
+    t!(ar.append_symlink("foo/bar", "../baz").await);
+    t!(ar.append_data("baz", 1, &b"x"[..]).await);
 
     let bytes = t!(ar.into_inner().await);
 
@@ -469,30 +362,27 @@ async fn malformed_pax_path_extension() {
     let mut ar_bytes = Vec::new();
 
     // First, create a PAX extension header with malformed content
-    let mut pax_header = async_tar::Header::new_ustar();
-    t!(pax_header.set_entry_type(async_tar::EntryType::new(b'x'))); // PAX local extensions
-    t!(pax_header.set_path("PaxHeaders/file"));
-
     // Create malformed PAX extension data - the length field doesn't match the actual content length
     // Format is: "<length> <key>=<value>\n" where length includes itself
     let malformed_pax = b"99 path=test.txt\n"; // Claims to be 99 bytes but is only 17 bytes
-    pax_header.set_size(malformed_pax.len() as u64);
-    pax_header.set_cksum();
+    let pax_header = raw_header(
+        b"PaxHeaders/file",
+        None,
+        b'x',
+        malformed_pax.len() as u64,
+        0o644,
+    );
 
     // Manually write the archive
-    ar_bytes.extend_from_slice(pax_header.as_bytes());
+    ar_bytes.extend_from_slice(pax_header.as_header().as_bytes());
     ar_bytes.extend_from_slice(malformed_pax);
     // Pad to 512 byte boundary
     let padding = (512 - (malformed_pax.len() % 512)) % 512;
     ar_bytes.extend_from_slice(&vec![0u8; padding]);
 
     // Now add the actual file entry
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(4);
-    t!(header.set_entry_type(async_tar::EntryType::Regular));
-    t!(header.set_path("file"));
-    header.set_cksum();
-    ar_bytes.extend_from_slice(header.as_bytes());
+    let header = raw_header(b"file", None, b'0', 4, 0o644);
+    ar_bytes.extend_from_slice(header.as_header().as_bytes());
     ar_bytes.extend_from_slice(b"test");
     // Pad to 512 byte boundary
     ar_bytes.extend_from_slice(&vec![0u8; 508]);
@@ -544,22 +434,10 @@ async fn symlink_dir_collision_does_not_chmod_external_dir() {
 
     // Add the entries to the archive: one symlink to the target, followed by
     // another entry of the same name that sets the target to 0777.
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Symlink));
-    t!(header.set_path("foo"));
-    t!(header.set_link_name(&target));
-    header.set_mode(0o777);
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
-
-    let mut header = async_tar::Header::new_ustar();
-    header.set_size(0);
-    t!(header.set_entry_type(async_tar::EntryType::Directory));
-    t!(header.set_path("foo"));
-    header.set_mode(0o777);
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+    t!(ar.append_symlink("foo", &target).await);
+    t!(ar
+        .append_directory_with_metadata("foo", async_tar::EntryMetadata::new().mode(0o777))
+        .await);
 
     // Get our raw archive.
     let bytes = t!(ar.into_inner().await);

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -24,47 +24,23 @@ fn raw_header(
     typeflag: u8,
     size: u64,
     mode: u32,
-) -> async_tar::UstarHeader {
-    let mut header: async_tar::UstarHeader = unsafe { std::mem::zeroed() };
-    header.name[..path.len()].copy_from_slice(path);
+) -> async_tar::Header {
+    let mut header = async_tar::Header::new_ustar();
+    header.as_old_mut().name[..path.len()].copy_from_slice(path);
     if let Some(target) = target {
-        header.linkname[..target.len()].copy_from_slice(target);
+        header.as_old_mut().linkname[..target.len()].copy_from_slice(target);
     }
-    header.typeflag = [typeflag];
-    header.magic = *b"ustar\0";
-    header.version = *b"00";
-    encode_octal(&mut header.mode, mode as u64);
-    encode_octal(&mut header.uid, 0);
-    encode_octal(&mut header.gid, 0);
-    encode_octal(&mut header.size, size);
-    encode_octal(&mut header.mtime, 0);
-    let checksum = header
-        .as_header()
-        .as_bytes()
-        .iter()
-        .enumerate()
-        .map(|(offset, byte)| {
-            if (148..156).contains(&offset) {
-                b' ' as u32
-            } else {
-                *byte as u32
-            }
-        })
-        .sum::<u32>();
-    encode_octal(&mut header.cksum, checksum as u64);
+    header.set_entry_type(async_tar::EntryType::new(typeflag));
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_size(size);
+    header.set_cksum();
     header
 }
 
-fn raw_link_header(path: &[u8], target: &[u8]) -> async_tar::UstarHeader {
+fn raw_link_header(path: &[u8], target: &[u8]) -> async_tar::Header {
     raw_header(path, Some(target), b'1', 0, 0o644)
-}
-
-fn encode_octal(dst: &mut [u8], value: u64) {
-    let octal = format!("{value:o}");
-    let value = std::iter::once(b'\0').chain(octal.bytes().rev().chain(std::iter::repeat(b'0')));
-    for (slot, value) in dst.iter_mut().rev().zip(value) {
-        *slot = value;
-    }
 }
 
 fn append_raw(bytes: &mut Vec<u8>, header: &async_tar::Header, data: &[u8]) {
@@ -98,12 +74,12 @@ async fn absolute_hardlink() {
     let td = t!(Builder::new().prefix("tar").tempdir());
     let mut bytes = Vec::new();
     let file_header = raw_header(b"foo", None, b'0', 0, 0o644);
-    append_raw(&mut bytes, file_header.as_header(), &[]);
+    append_raw(&mut bytes, &file_header, &[]);
 
     // This absolute path under tempdir will be created at unpack time
     let target = td.path().join("foo");
     let header = raw_link_header(b"bar", target.to_str().unwrap().as_bytes());
-    append_raw(&mut bytes, header.as_header(), &[]);
+    append_raw(&mut bytes, &header, &[]);
     bytes.extend_from_slice(&[0; 1024]);
 
     let mut ar = async_tar::Archive::new(&bytes[..]);
@@ -267,7 +243,7 @@ async fn good_parent_paths_ok() {
 async fn modify_hard_link_just_created() {
     let mut bytes = Vec::new();
     let header = raw_link_header(b"foo", b"../test");
-    append_raw(&mut bytes, header.as_header(), &[]);
+    append_raw(&mut bytes, &header, &[]);
     let mut ar = async_tar::Builder::new(bytes);
 
     t!(ar.append_data("foo", 1, &b"x"[..]).await);
@@ -374,7 +350,7 @@ async fn malformed_pax_path_extension() {
     );
 
     // Manually write the archive
-    ar_bytes.extend_from_slice(pax_header.as_header().as_bytes());
+    ar_bytes.extend_from_slice(pax_header.as_bytes());
     ar_bytes.extend_from_slice(malformed_pax);
     // Pad to 512 byte boundary
     let padding = (512 - (malformed_pax.len() % 512)) % 512;
@@ -382,7 +358,7 @@ async fn malformed_pax_path_extension() {
 
     // Now add the actual file entry
     let header = raw_header(b"file", None, b'0', 4, 0o644);
-    ar_bytes.extend_from_slice(header.as_header().as_bytes());
+    ar_bytes.extend_from_slice(header.as_bytes());
     ar_bytes.extend_from_slice(b"test");
     // Pad to 512 byte boundary
     ar_bytes.extend_from_slice(&vec![0u8; 508]);

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -22,9 +22,9 @@ macro_rules! t {
 async fn absolute_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("/bar"));
     header.set_cksum();
@@ -49,16 +49,16 @@ async fn absolute_hardlink() {
     let td = t!(Builder::new().prefix("tar").tempdir());
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
+    t!(header.set_entry_type(async_tar::EntryType::Link));
     t!(header.set_path("bar"));
     // This absolute path under tempdir will be created at unpack time
     t!(header.set_link_name(td.path().join("foo")));
@@ -77,16 +77,16 @@ async fn absolute_hardlink() {
 async fn relative_hardlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
+    t!(header.set_entry_type(async_tar::EntryType::Link));
     t!(header.set_path("bar"));
     t!(header.set_link_name("foo"));
     header.set_cksum();
@@ -105,17 +105,17 @@ async fn relative_hardlink() {
 async fn absolute_link_deref_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("/"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo/bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -133,17 +133,17 @@ async fn absolute_link_deref_error() {
 async fn relative_link_deref_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("../../../../"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo/bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -164,9 +164,9 @@ async fn directory_permissions_are_cleared() {
 
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Directory);
+    t!(header.set_entry_type(async_tar::EntryType::Directory));
     t!(header.set_path("foo"));
     header.set_mode(0o777);
     header.set_cksum();
@@ -198,24 +198,24 @@ async fn directory_permissions_are_cleared() {
 async fn modify_link_just_created() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("bar/foo"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo/bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -237,17 +237,17 @@ async fn modify_link_just_created() {
 async fn modify_outside_with_relative_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("symlink"));
     t!(header.set_link_name(".."));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("symlink/foo/bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -265,17 +265,17 @@ async fn modify_outside_with_relative_symlink() {
 async fn parent_paths_error() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name(".."));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo/bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -295,17 +295,17 @@ async fn good_parent_paths_ok() {
     use std::path::PathBuf;
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path(PathBuf::from("foo").join("bar")));
     t!(header.set_link_name(PathBuf::from("..").join("bar")));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("bar"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
@@ -324,17 +324,17 @@ async fn good_parent_paths_ok() {
 async fn modify_hard_link_just_created() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
+    t!(header.set_entry_type(async_tar::EntryType::Link));
     t!(header.set_path("foo"));
     t!(header.set_link_name("../test"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(1);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo"));
     header.set_cksum();
     t!(ar.append(&header, &b"x"[..]).await);
@@ -359,17 +359,17 @@ async fn modify_hard_link_just_created() {
 async fn modify_symlink_just_created() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("../test"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(1);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("foo"));
     header.set_cksum();
     t!(ar.append(&header, &b"x"[..]).await);
@@ -394,9 +394,9 @@ async fn modify_symlink_just_created() {
 async fn deny_absolute_symlink() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("/bar"));
     header.set_cksum();
@@ -415,9 +415,9 @@ async fn deny_absolute_symlink() {
 async fn deny_relative_link() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name("../../../../"));
     header.set_cksum();
@@ -437,17 +437,17 @@ async fn deny_relative_link() {
 async fn accept_relative_link() {
     let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo/bar"));
     t!(header.set_link_name("../baz"));
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(1);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("baz"));
     header.set_cksum();
     t!(ar.append(&header, &b"x"[..]).await);
@@ -469,8 +469,8 @@ async fn malformed_pax_path_extension() {
     let mut ar_bytes = Vec::new();
 
     // First, create a PAX extension header with malformed content
-    let mut pax_header = async_tar::Header::new_gnu();
-    pax_header.set_entry_type(async_tar::EntryType::new(b'x')); // PAX local extensions
+    let mut pax_header = async_tar::Header::new_ustar();
+    t!(pax_header.set_entry_type(async_tar::EntryType::new(b'x'))); // PAX local extensions
     t!(pax_header.set_path("PaxHeaders/file"));
 
     // Create malformed PAX extension data - the length field doesn't match the actual content length
@@ -487,9 +487,9 @@ async fn malformed_pax_path_extension() {
     ar_bytes.extend_from_slice(&vec![0u8; padding]);
 
     // Now add the actual file entry
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(4);
-    header.set_entry_type(async_tar::EntryType::Regular);
+    t!(header.set_entry_type(async_tar::EntryType::Regular));
     t!(header.set_path("file"));
     header.set_cksum();
     ar_bytes.extend_from_slice(header.as_bytes());
@@ -544,18 +544,18 @@ async fn symlink_dir_collision_does_not_chmod_external_dir() {
 
     // Add the entries to the archive: one symlink to the target, followed by
     // another entry of the same name that sets the target to 0777.
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
+    t!(header.set_entry_type(async_tar::EntryType::Symlink));
     t!(header.set_path("foo"));
     t!(header.set_link_name(&target));
     header.set_mode(0o777);
     header.set_cksum();
     t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
+    let mut header = async_tar::Header::new_ustar();
     header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Directory);
+    t!(header.set_entry_type(async_tar::EntryType::Directory));
     t!(header.set_path("foo"));
     header.set_mode(0o777);
     header.set_cksum();

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -1,141 +1,250 @@
-use std::{mem, path::Path};
+#![allow(clippy::cognitive_complexity)]
 
-use async_tar::{GnuHeader, Header, OldHeader, UstarHeader};
+use std::{
+    fs::{self, File},
+    io::Write,
+    mem,
+    path::Path,
+    thread, time,
+};
 
-fn gnu_header() -> GnuHeader {
-    let mut header: GnuHeader = unsafe { mem::zeroed() };
-    header.magic = *b"ustar ";
-    header.version = *b" \0";
-    header.mtime = *b"00000000000\0";
-    header
-}
+use tempfile::Builder;
 
-fn old_header() -> OldHeader {
-    let mut header: OldHeader = unsafe { mem::zeroed() };
-    header.mtime = *b"00000000000\0";
-    header
-}
-
-fn ustar_header() -> UstarHeader {
-    let mut header: UstarHeader = unsafe { mem::zeroed() };
-    header.magic = *b"ustar\0";
-    header.version = *b"00";
-    header.mtime = *b"00000000000\0";
-    header
-}
+use async_tar::{GnuHeader, Header, HeaderMode};
 
 #[test]
-fn goto_gnu() {
-    let h = gnu_header();
-    assert!(h.as_header().as_gnu().is_some());
-    assert!(h.as_header().as_ustar().is_none());
+fn default_gnu() {
+    let mut h = Header::new_gnu();
+    assert!(h.as_gnu().is_some());
+    assert!(h.as_gnu_mut().is_some());
+    assert!(h.as_ustar().is_none());
+    assert!(h.as_ustar_mut().is_none());
 }
 
 #[test]
 fn goto_old() {
-    let h = old_header();
-    assert!(h.as_header().as_gnu().is_none());
-    assert!(h.as_header().as_ustar().is_none());
+    let mut h = Header::new_old();
+    assert!(h.as_gnu().is_none());
+    assert!(h.as_gnu_mut().is_none());
+    assert!(h.as_ustar().is_none());
+    assert!(h.as_ustar_mut().is_none());
 }
 
 #[test]
 fn goto_ustar() {
-    let h = ustar_header();
-    assert!(h.as_header().as_gnu().is_none());
-    assert!(h.as_header().as_ustar().is_some());
+    let mut h = Header::new_ustar();
+    assert!(h.as_gnu().is_none());
+    assert!(h.as_gnu_mut().is_none());
+    assert!(h.as_ustar().is_some());
+    assert!(h.as_ustar_mut().is_some());
 }
 
 #[test]
 fn link_name() {
-    let mut h = ustar_header();
-    h.linkname[..10].copy_from_slice(b"../foo/bar");
-    assert_eq!(
-        t!(h.as_header().link_name()).unwrap().to_str(),
-        Some("../foo/bar")
-    );
+    let mut h = Header::new_gnu();
+    t!(h.set_link_name("foo"));
+    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo"));
+    t!(h.set_link_name("../foo"));
+    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("../foo"));
+    t!(h.set_link_name("foo/bar"));
+    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo/bar"));
+    t!(h.set_link_name("foo\\ba"));
+    if cfg!(windows) {
+        assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo/ba"));
+    } else {
+        assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo\\ba"));
+    }
 
-    h.linkname = [0; 100];
-    h.linkname[..8].copy_from_slice(b"foo\\bar\0");
-    assert_eq!(
-        t!(h.as_header().link_name()).unwrap().to_str(),
-        Some("foo\\bar")
-    );
+    let name = "foo\\bar\0";
+    for (slot, val) in h.as_old_mut().linkname.iter_mut().zip(name.as_bytes()) {
+        *slot = *val;
+    }
+    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo\\bar"));
+
+    assert!(h.set_link_name("\0").is_err());
 }
 
 #[test]
 fn mtime() {
-    assert_eq!(t!(gnu_header().as_header().mtime()), 0);
-    assert_eq!(t!(ustar_header().as_header().mtime()), 0);
-    assert_eq!(t!(old_header().as_header().mtime()), 0);
+    let h = Header::new_gnu();
+    assert_eq!(t!(h.mtime()), 0);
+
+    let h = Header::new_ustar();
+    assert_eq!(t!(h.mtime()), 0);
+
+    let h = Header::new_old();
+    assert_eq!(t!(h.mtime()), 0);
 }
 
 #[test]
 fn user_and_group_name() {
-    let mut h = gnu_header();
-    h.uname[..3].copy_from_slice(b"foo");
-    h.gname[..3].copy_from_slice(b"bar");
-    assert_eq!(t!(h.as_header().username()), Some("foo"));
-    assert_eq!(t!(h.as_header().groupname()), Some("bar"));
+    let mut h = Header::new_gnu();
+    t!(h.set_username("foo"));
+    t!(h.set_groupname("bar"));
+    assert_eq!(t!(h.username()), Some("foo"));
+    assert_eq!(t!(h.groupname()), Some("bar"));
 
-    let mut h = ustar_header();
-    h.uname[..3].copy_from_slice(b"foo");
-    h.gname[..3].copy_from_slice(b"bar");
-    assert_eq!(t!(h.as_header().username()), Some("foo"));
-    assert_eq!(t!(h.as_header().groupname()), Some("bar"));
+    h = Header::new_ustar();
+    t!(h.set_username("foo"));
+    t!(h.set_groupname("bar"));
+    assert_eq!(t!(h.username()), Some("foo"));
+    assert_eq!(t!(h.groupname()), Some("bar"));
 
-    let h = old_header();
-    assert_eq!(t!(h.as_header().username()), None);
-    assert_eq!(t!(h.as_header().groupname()), None);
+    h = Header::new_old();
+    assert_eq!(t!(h.username()), None);
+    assert_eq!(t!(h.groupname()), None);
+    assert!(h.set_username("foo").is_err());
+    assert!(h.set_groupname("foo").is_err());
 }
 
 #[test]
 fn dev_major_minor() {
-    let mut h = ustar_header();
-    h.dev_major = *b"0000001\0";
-    h.dev_minor = *b"0000002\0";
-    assert_eq!(t!(h.as_header().device_major()), Some(1));
-    assert_eq!(t!(h.as_header().device_minor()), Some(2));
+    let mut h = Header::new_gnu();
+    t!(h.set_device_major(1));
+    t!(h.set_device_minor(2));
+    assert_eq!(t!(h.device_major()), Some(1));
+    assert_eq!(t!(h.device_minor()), Some(2));
 
-    h.dev_major[0] = 0x7f;
-    h.dev_minor[0] = b'g';
-    assert!(h.as_header().device_major().is_err());
-    assert!(h.as_header().device_minor().is_err());
+    h = Header::new_ustar();
+    t!(h.set_device_major(1));
+    t!(h.set_device_minor(2));
+    assert_eq!(t!(h.device_major()), Some(1));
+    assert_eq!(t!(h.device_minor()), Some(2));
 
-    let h = old_header();
-    assert_eq!(t!(h.as_header().device_major()), None);
-    assert_eq!(t!(h.as_header().device_minor()), None);
+    h.as_ustar_mut().unwrap().dev_minor[0] = 0x7f;
+    h.as_ustar_mut().unwrap().dev_major[0] = 0x7f;
+    assert!(h.device_major().is_err());
+    assert!(h.device_minor().is_err());
+
+    h.as_ustar_mut().unwrap().dev_minor[0] = b'g';
+    h.as_ustar_mut().unwrap().dev_major[0] = b'h';
+    assert!(h.device_major().is_err());
+    assert!(h.device_minor().is_err());
+
+    h = Header::new_old();
+    assert_eq!(t!(h.device_major()), None);
+    assert_eq!(t!(h.device_minor()), None);
+    assert!(h.set_device_major(1).is_err());
+    assert!(h.set_device_minor(1).is_err());
 }
 
 #[test]
-fn path() {
-    let mut h = ustar_header();
-    h.name[..3].copy_from_slice(b"bar");
-    h.prefix[..3].copy_from_slice(b"foo");
-    assert_eq!(t!(h.as_header().path()), Path::new("foo/bar"));
+fn set_path() {
+    let mut h = Header::new_gnu();
+    t!(h.set_path("foo"));
+    assert_eq!(t!(h.path()).to_str(), Some("foo"));
+    t!(h.set_path("foo/"));
+    assert_eq!(t!(h.path()).to_str(), Some("foo/"));
+    t!(h.set_path("foo/bar"));
+    assert_eq!(t!(h.path()).to_str(), Some("foo/bar"));
+    t!(h.set_path("foo\\bar"));
+    if cfg!(windows) {
+        assert_eq!(t!(h.path()).to_str(), Some("foo/bar"));
+    } else {
+        assert_eq!(t!(h.path()).to_str(), Some("foo\\bar"));
+    }
 
-    h.name = [0; 100];
-    h.prefix = [0; 155];
-    h.name[..7].copy_from_slice(b"foo\\bar");
-    assert_eq!(t!(h.as_header().path()), Path::new("foo\\bar"));
+    // set_path documentation explictly states it removes any ".", signfying the
+    // current directory, from the path. This test ensures that documented
+    // beavhior occurs
+    t!(h.set_path("./control"));
+    assert_eq!(t!(h.path()).to_str(), Some("control"));
+
+    let long_name = "foo".repeat(100);
+    let medium1 = "foo".repeat(52);
+    let medium2 = "fo/".repeat(52);
+
+    assert!(h.set_path(&long_name).is_err());
+    assert!(h.set_path(&medium1).is_err());
+    assert!(h.set_path(&medium2).is_err());
+    assert!(h.set_path("\0").is_err());
+
+    assert!(h.set_path("..").is_err());
+    assert!(h.set_path("foo/..").is_err());
+    assert!(h.set_path("foo/../bar").is_err());
+
+    h = Header::new_ustar();
+    t!(h.set_path("foo"));
+    assert_eq!(t!(h.path()).to_str(), Some("foo"));
+
+    assert!(h.set_path(&long_name).is_err());
+    assert!(h.set_path(&medium1).is_err());
+    t!(h.set_path(&medium2));
+    assert_eq!(t!(h.path()).to_str(), Some(&medium2[..]));
 }
 
 #[test]
-fn extended_numeric_format_reading() {
-    let mut h = ustar_header();
-    h.size = *b"00000000052\0";
-    h.gid = *b"0000052\0";
-    assert_eq!(t!(h.as_header().size()), 42);
-    assert_eq!(t!(h.as_header().gid()), 42);
+fn set_ustar_path_hard() {
+    let mut h = Header::new_ustar();
+    let p = Path::new("a").join(vec!["a"; 100].join(""));
+    t!(h.set_path(&p));
+    let path = t!(h.path());
+    let actual: &Path = path.as_ref();
+    assert_eq!(actual, p);
+}
 
-    let mut h = gnu_header();
+#[test]
+fn set_metadata_deterministic() {
+    let td = t!(Builder::new().prefix("async-tar").tempdir());
+    let tmppath = td.path().join("tmpfile");
+
+    fn mk_header(path: &Path, readonly: bool) -> Header {
+        let mut file = t!(File::create(path));
+        t!(file.write_all(b"c"));
+        let mut perms = t!(file.metadata()).permissions();
+        perms.set_readonly(readonly);
+        t!(fs::set_permissions(path, perms));
+        let mut h = Header::new_ustar();
+        h.set_metadata_in_mode(&t!(path.metadata()), HeaderMode::Deterministic);
+        h
+    }
+
+    // Create "the same" File twice in a row, one second apart, with differing readonly values.
+    let one = mk_header(tmppath.as_path(), false);
+    thread::sleep(time::Duration::from_millis(1050));
+    let two = mk_header(tmppath.as_path(), true);
+
+    // Always expected to match.
+    assert_eq!(t!(one.size()), t!(two.size()));
+    assert_eq!(t!(one.path()), t!(two.path()));
+    assert_eq!(t!(one.mode()), t!(two.mode()));
+
+    // Would not match without `Deterministic`.
+    assert_eq!(t!(one.mtime()), t!(two.mtime()));
+    // TODO: No great way to validate that these would not be filled, but
+    // check them anyway.
+    assert_eq!(t!(one.uid()), t!(two.uid()));
+    assert_eq!(t!(one.gid()), t!(two.gid()));
+}
+
+#[test]
+fn extended_numeric_format() {
+    let mut h: GnuHeader = unsafe { mem::zeroed() };
+    h.as_header_mut().set_size(42);
+    assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]);
+    h.as_header_mut().set_size(8589934593);
+    assert_eq!(h.size, [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 1]);
+    h.as_header_mut().set_size(44);
+    assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 52, 0]);
     h.size = [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 0];
     assert_eq!(h.as_header().entry_size().unwrap(), 0x0200000000);
+    h.size = [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 51, 0];
+    assert_eq!(h.as_header().entry_size().unwrap(), 43);
+
+    h.as_header_mut().set_gid(42);
+    assert_eq!(h.gid, [48, 48, 48, 48, 48, 53, 50, 0]);
+    assert_eq!(h.as_header().gid().unwrap(), 42);
+    h.as_header_mut().set_gid(0x7fffffffffffffff);
+    assert_eq!(h.gid, [0xff; 8]);
+    assert_eq!(h.as_header().gid().unwrap(), 0x7fffffffffffffff);
     h.uid = [0x80, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78];
     assert_eq!(h.as_header().uid().unwrap(), 0x12345678);
+
     h.mtime = [
         0x80, 0, 0, 0, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
     ];
     assert_eq!(h.as_header().mtime().unwrap(), 0x0123456789abcdef);
+
     h.realsize = [0x80, 0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde];
     assert_eq!(h.real_size().unwrap(), 0x00123456789abcde);
     h.sparse[0].offset = [0x80, 0, 0, 0, 0, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd];
@@ -146,8 +255,8 @@ fn extended_numeric_format_reading() {
 
 #[test]
 fn byte_slice_conversion() {
-    let h = ustar_header();
-    let b = h.as_header().as_bytes();
-    let b_conv = Header::from_byte_slice(b).as_bytes();
+    let h = Header::new_gnu();
+    let b: &[u8] = h.as_bytes();
+    let b_conv: &[u8] = Header::from_byte_slice(h.as_bytes()).as_bytes();
     assert_eq!(b, b_conv);
 }

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -1,16 +1,6 @@
-#![allow(clippy::cognitive_complexity)]
+use std::{mem, path::Path};
 
-use std::{
-    fs::{self, File},
-    io::Write,
-    mem,
-    path::Path,
-    thread, time,
-};
-
-use tempfile::Builder;
-
-use async_tar::{GnuHeader, Header, HeaderMode, OldHeader, UstarHeader};
+use async_tar::{GnuHeader, Header, OldHeader, UstarHeader};
 
 fn gnu_header() -> GnuHeader {
     let mut header: GnuHeader = unsafe { mem::zeroed() };
@@ -22,6 +12,14 @@ fn gnu_header() -> GnuHeader {
 
 fn old_header() -> OldHeader {
     let mut header: OldHeader = unsafe { mem::zeroed() };
+    header.mtime = *b"00000000000\0";
+    header
+}
+
+fn ustar_header() -> UstarHeader {
+    let mut header: UstarHeader = unsafe { mem::zeroed() };
+    header.magic = *b"ustar\0";
+    header.version = *b"00";
     header.mtime = *b"00000000000\0";
     header
 }
@@ -42,49 +40,33 @@ fn goto_old() {
 
 #[test]
 fn goto_ustar() {
-    let h = Header::new_ustar();
-    assert!(h.as_gnu().is_none());
-    assert!(h.as_ustar().is_some());
+    let h = ustar_header();
+    assert!(h.as_header().as_gnu().is_none());
+    assert!(h.as_header().as_ustar().is_some());
 }
 
 #[test]
 fn link_name() {
-    let mut h = Header::new_ustar();
-    t!(h.set_link_name("foo"));
-    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo"));
-    t!(h.set_link_name("../foo"));
-    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("../foo"));
-    t!(h.set_link_name("foo/bar"));
-    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo/bar"));
-    t!(h.set_link_name("foo\\ba"));
-    if cfg!(windows) {
-        assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo/ba"));
-    } else {
-        assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo\\ba"));
-    }
-
-    let mut raw: UstarHeader = unsafe { mem::zeroed() };
-    raw.magic = *b"ustar\0";
-    raw.version = *b"00";
-    raw.linkname[..8].copy_from_slice(b"foo\\bar\0");
+    let mut h = ustar_header();
+    h.linkname[..10].copy_from_slice(b"../foo/bar");
     assert_eq!(
-        t!(raw.as_header().link_name()).unwrap().to_str(),
-        Some("foo\\bar")
+        t!(h.as_header().link_name()).unwrap().to_str(),
+        Some("../foo/bar")
     );
 
-    assert!(h.set_link_name("\0").is_err());
+    h.linkname = [0; 100];
+    h.linkname[..8].copy_from_slice(b"foo\\bar\0");
+    assert_eq!(
+        t!(h.as_header().link_name()).unwrap().to_str(),
+        Some("foo\\bar")
+    );
 }
 
 #[test]
 fn mtime() {
-    let h = gnu_header();
-    assert_eq!(t!(h.as_header().mtime()), 0);
-
-    let h = Header::new_ustar();
-    assert_eq!(t!(h.mtime()), 0);
-
-    let h = old_header();
-    assert_eq!(t!(h.as_header().mtime()), 0);
+    assert_eq!(t!(gnu_header().as_header().mtime()), 0);
+    assert_eq!(t!(ustar_header().as_header().mtime()), 0);
+    assert_eq!(t!(old_header().as_header().mtime()), 0);
 }
 
 #[test]
@@ -95,11 +77,11 @@ fn user_and_group_name() {
     assert_eq!(t!(h.as_header().username()), Some("foo"));
     assert_eq!(t!(h.as_header().groupname()), Some("bar"));
 
-    let mut h = Header::new_ustar();
-    t!(h.set_username("foo"));
-    t!(h.set_groupname("bar"));
-    assert_eq!(t!(h.username()), Some("foo"));
-    assert_eq!(t!(h.groupname()), Some("bar"));
+    let mut h = ustar_header();
+    h.uname[..3].copy_from_slice(b"foo");
+    h.gname[..3].copy_from_slice(b"bar");
+    assert_eq!(t!(h.as_header().username()), Some("foo"));
+    assert_eq!(t!(h.as_header().groupname()), Some("bar"));
 
     let h = old_header();
     assert_eq!(t!(h.as_header().username()), None);
@@ -108,30 +90,16 @@ fn user_and_group_name() {
 
 #[test]
 fn dev_major_minor() {
-    let mut h = gnu_header();
+    let mut h = ustar_header();
     h.dev_major = *b"0000001\0";
     h.dev_minor = *b"0000002\0";
     assert_eq!(t!(h.as_header().device_major()), Some(1));
     assert_eq!(t!(h.as_header().device_minor()), Some(2));
 
-    let mut h = Header::new_ustar();
-    t!(h.set_device_major(1));
-    t!(h.set_device_minor(2));
-    assert_eq!(t!(h.device_major()), Some(1));
-    assert_eq!(t!(h.device_minor()), Some(2));
-
-    let mut raw: UstarHeader = unsafe { mem::zeroed() };
-    raw.magic = *b"ustar\0";
-    raw.version = *b"00";
-    raw.dev_minor[0] = 0x7f;
-    raw.dev_major[0] = 0x7f;
-    assert!(raw.as_header().device_major().is_err());
-    assert!(raw.as_header().device_minor().is_err());
-
-    raw.dev_minor[0] = b'g';
-    raw.dev_major[0] = b'h';
-    assert!(raw.as_header().device_major().is_err());
-    assert!(raw.as_header().device_minor().is_err());
+    h.dev_major[0] = 0x7f;
+    h.dev_minor[0] = b'g';
+    assert!(h.as_header().device_major().is_err());
+    assert!(h.as_header().device_minor().is_err());
 
     let h = old_header();
     assert_eq!(t!(h.as_header().device_major()), None);
@@ -139,134 +107,35 @@ fn dev_major_minor() {
 }
 
 #[test]
-fn set_path() {
-    let mut h = Header::new_ustar();
-    t!(h.set_path("foo"));
-    assert_eq!(t!(h.path()).to_str(), Some("foo"));
-    t!(h.set_path("foo/"));
-    assert_eq!(t!(h.path()).to_str(), Some("foo/"));
-    t!(h.set_path("foo/bar"));
-    assert_eq!(t!(h.path()).to_str(), Some("foo/bar"));
-    t!(h.set_path("foo\\bar"));
-    if cfg!(windows) {
-        assert_eq!(t!(h.path()).to_str(), Some("foo/bar"));
-    } else {
-        assert_eq!(t!(h.path()).to_str(), Some("foo\\bar"));
-    }
+fn path() {
+    let mut h = ustar_header();
+    h.name[..3].copy_from_slice(b"bar");
+    h.prefix[..3].copy_from_slice(b"foo");
+    assert_eq!(t!(h.as_header().path()), Path::new("foo/bar"));
 
-    // set_path documentation explictly states it removes any ".", signfying the
-    // current directory, from the path. This test ensures that documented
-    // beavhior occurs
-    t!(h.set_path("./control"));
-    assert_eq!(t!(h.path()).to_str(), Some("control"));
-
-    let long_name = "foo".repeat(100);
-    let medium1 = "foo".repeat(52);
-    let medium2 = "fo/".repeat(52);
-
-    assert!(h.set_path(&long_name).is_err());
-    assert!(h.set_path(&medium1).is_err());
-    t!(h.set_path(&medium2));
-    assert_eq!(t!(h.path()).to_str(), Some(&medium2[..]));
-    assert!(h.set_path("\0").is_err());
-
-    assert!(h.set_path("..").is_err());
-    assert!(h.set_path("foo/..").is_err());
-    assert!(h.set_path("foo/../bar").is_err());
-
-    h = Header::new_ustar();
-    t!(h.set_path("foo"));
-    assert_eq!(t!(h.path()).to_str(), Some("foo"));
-
-    assert!(h.set_path(&long_name).is_err());
-    assert!(h.set_path(&medium1).is_err());
-    t!(h.set_path(&medium2));
-    assert_eq!(t!(h.path()).to_str(), Some(&medium2[..]));
+    h.name = [0; 100];
+    h.prefix = [0; 155];
+    h.name[..7].copy_from_slice(b"foo\\bar");
+    assert_eq!(t!(h.as_header().path()), Path::new("foo\\bar"));
 }
 
 #[test]
-fn set_ustar_path_hard() {
-    let mut h = Header::new_ustar();
-    let p = Path::new("a").join(vec!["a"; 100].join(""));
-    t!(h.set_path(&p));
-    let path = t!(h.path());
-    let actual: &Path = path.as_ref();
-    assert_eq!(actual, p);
-}
+fn extended_numeric_format_reading() {
+    let mut h = ustar_header();
+    h.size = *b"00000000052\0";
+    h.gid = *b"0000052\0";
+    assert_eq!(t!(h.as_header().size()), 42);
+    assert_eq!(t!(h.as_header().gid()), 42);
 
-#[test]
-fn set_metadata_deterministic() {
-    let td = t!(Builder::new().prefix("async-tar").tempdir());
-    let tmppath = td.path().join("tmpfile");
-
-    fn mk_header(path: &Path, readonly: bool) -> Header {
-        let mut file = t!(File::create(path));
-        t!(file.write_all(b"c"));
-        let mut perms = t!(file.metadata()).permissions();
-        perms.set_readonly(readonly);
-        t!(fs::set_permissions(path, perms));
-        let mut h = Header::new_ustar();
-        h.set_metadata_in_mode(&t!(path.metadata()), HeaderMode::Deterministic);
-        h
-    }
-
-    // Create "the same" File twice in a row, one second apart, with differing readonly values.
-    let one = mk_header(tmppath.as_path(), false);
-    thread::sleep(time::Duration::from_millis(1050));
-    let two = mk_header(tmppath.as_path(), true);
-
-    // Always expected to match.
-    assert_eq!(t!(one.size()), t!(two.size()));
-    assert_eq!(t!(one.path()), t!(two.path()));
-    assert_eq!(t!(one.mode()), t!(two.mode()));
-
-    // Would not match without `Deterministic`.
-    assert_eq!(t!(one.mtime()), t!(two.mtime()));
-    // TODO: No great way to validate that these would not be filled, but
-    // check them anyway.
-    assert_eq!(t!(one.uid()), t!(two.uid()));
-    assert_eq!(t!(one.gid()), t!(two.gid()));
-}
-
-#[test]
-fn extended_numeric_format() {
-    let mut header = Header::new_ustar();
-    header.set_size(42);
-    assert_eq!(
-        header.as_old().size,
-        [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]
-    );
-    header.set_size(8589934593);
-    assert_eq!(
-        header.as_old().size,
-        [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 1]
-    );
-    header.set_size(44);
-    assert_eq!(
-        header.as_old().size,
-        [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 52, 0]
-    );
-
-    let mut h: GnuHeader = unsafe { mem::zeroed() };
+    let mut h = gnu_header();
     h.size = [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 0];
     assert_eq!(h.as_header().entry_size().unwrap(), 0x0200000000);
-    h.size = [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 51, 0];
-    assert_eq!(h.as_header().entry_size().unwrap(), 43);
-
-    header.set_gid(42);
-    assert_eq!(header.as_old().gid, [48, 48, 48, 48, 48, 53, 50, 0]);
-    assert_eq!(header.gid().unwrap(), 42);
-    header.set_gid(0x7fffffffffffffff);
-    assert_eq!(header.as_old().gid, [0xff; 8]);
-    assert_eq!(header.gid().unwrap(), 0x7fffffffffffffff);
     h.uid = [0x80, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78];
     assert_eq!(h.as_header().uid().unwrap(), 0x12345678);
-
     h.mtime = [
         0x80, 0, 0, 0, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
     ];
     assert_eq!(h.as_header().mtime().unwrap(), 0x0123456789abcdef);
-
     h.realsize = [0x80, 0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde];
     assert_eq!(h.real_size().unwrap(), 0x00123456789abcde);
     h.sparse[0].offset = [0x80, 0, 0, 0, 0, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd];
@@ -277,8 +146,8 @@ fn extended_numeric_format() {
 
 #[test]
 fn byte_slice_conversion() {
-    let h = Header::new_ustar();
-    let b: &[u8] = h.as_bytes();
-    let b_conv: &[u8] = Header::from_byte_slice(h.as_bytes()).as_bytes();
+    let h = ustar_header();
+    let b = h.as_header().as_bytes();
+    let b_conv = Header::from_byte_slice(b).as_bytes();
     assert_eq!(b, b_conv);
 }

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -10,38 +10,46 @@ use std::{
 
 use tempfile::Builder;
 
-use async_tar::{GnuHeader, Header, HeaderMode};
+use async_tar::{GnuHeader, Header, HeaderMode, OldHeader, UstarHeader};
+
+fn gnu_header() -> GnuHeader {
+    let mut header: GnuHeader = unsafe { mem::zeroed() };
+    header.magic = *b"ustar ";
+    header.version = *b" \0";
+    header.mtime = *b"00000000000\0";
+    header
+}
+
+fn old_header() -> OldHeader {
+    let mut header: OldHeader = unsafe { mem::zeroed() };
+    header.mtime = *b"00000000000\0";
+    header
+}
 
 #[test]
-fn default_gnu() {
-    let mut h = Header::new_gnu();
-    assert!(h.as_gnu().is_some());
-    assert!(h.as_gnu_mut().is_some());
-    assert!(h.as_ustar().is_none());
-    assert!(h.as_ustar_mut().is_none());
+fn goto_gnu() {
+    let h = gnu_header();
+    assert!(h.as_header().as_gnu().is_some());
+    assert!(h.as_header().as_ustar().is_none());
 }
 
 #[test]
 fn goto_old() {
-    let mut h = Header::new_old();
-    assert!(h.as_gnu().is_none());
-    assert!(h.as_gnu_mut().is_none());
-    assert!(h.as_ustar().is_none());
-    assert!(h.as_ustar_mut().is_none());
+    let h = old_header();
+    assert!(h.as_header().as_gnu().is_none());
+    assert!(h.as_header().as_ustar().is_none());
 }
 
 #[test]
 fn goto_ustar() {
-    let mut h = Header::new_ustar();
+    let h = Header::new_ustar();
     assert!(h.as_gnu().is_none());
-    assert!(h.as_gnu_mut().is_none());
     assert!(h.as_ustar().is_some());
-    assert!(h.as_ustar_mut().is_some());
 }
 
 #[test]
 fn link_name() {
-    let mut h = Header::new_gnu();
+    let mut h = Header::new_ustar();
     t!(h.set_link_name("foo"));
     assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo"));
     t!(h.set_link_name("../foo"));
@@ -55,82 +63,84 @@ fn link_name() {
         assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo\\ba"));
     }
 
-    let name = "foo\\bar\0";
-    for (slot, val) in h.as_old_mut().linkname.iter_mut().zip(name.as_bytes()) {
-        *slot = *val;
-    }
-    assert_eq!(t!(h.link_name()).unwrap().to_str(), Some("foo\\bar"));
+    let mut raw: UstarHeader = unsafe { mem::zeroed() };
+    raw.magic = *b"ustar\0";
+    raw.version = *b"00";
+    raw.linkname[..8].copy_from_slice(b"foo\\bar\0");
+    assert_eq!(
+        t!(raw.as_header().link_name()).unwrap().to_str(),
+        Some("foo\\bar")
+    );
 
     assert!(h.set_link_name("\0").is_err());
 }
 
 #[test]
 fn mtime() {
-    let h = Header::new_gnu();
-    assert_eq!(t!(h.mtime()), 0);
+    let h = gnu_header();
+    assert_eq!(t!(h.as_header().mtime()), 0);
 
     let h = Header::new_ustar();
     assert_eq!(t!(h.mtime()), 0);
 
-    let h = Header::new_old();
-    assert_eq!(t!(h.mtime()), 0);
+    let h = old_header();
+    assert_eq!(t!(h.as_header().mtime()), 0);
 }
 
 #[test]
 fn user_and_group_name() {
-    let mut h = Header::new_gnu();
+    let mut h = gnu_header();
+    h.uname[..3].copy_from_slice(b"foo");
+    h.gname[..3].copy_from_slice(b"bar");
+    assert_eq!(t!(h.as_header().username()), Some("foo"));
+    assert_eq!(t!(h.as_header().groupname()), Some("bar"));
+
+    let mut h = Header::new_ustar();
     t!(h.set_username("foo"));
     t!(h.set_groupname("bar"));
     assert_eq!(t!(h.username()), Some("foo"));
     assert_eq!(t!(h.groupname()), Some("bar"));
 
-    h = Header::new_ustar();
-    t!(h.set_username("foo"));
-    t!(h.set_groupname("bar"));
-    assert_eq!(t!(h.username()), Some("foo"));
-    assert_eq!(t!(h.groupname()), Some("bar"));
-
-    h = Header::new_old();
-    assert_eq!(t!(h.username()), None);
-    assert_eq!(t!(h.groupname()), None);
-    assert!(h.set_username("foo").is_err());
-    assert!(h.set_groupname("foo").is_err());
+    let h = old_header();
+    assert_eq!(t!(h.as_header().username()), None);
+    assert_eq!(t!(h.as_header().groupname()), None);
 }
 
 #[test]
 fn dev_major_minor() {
-    let mut h = Header::new_gnu();
+    let mut h = gnu_header();
+    h.dev_major = *b"0000001\0";
+    h.dev_minor = *b"0000002\0";
+    assert_eq!(t!(h.as_header().device_major()), Some(1));
+    assert_eq!(t!(h.as_header().device_minor()), Some(2));
+
+    let mut h = Header::new_ustar();
     t!(h.set_device_major(1));
     t!(h.set_device_minor(2));
     assert_eq!(t!(h.device_major()), Some(1));
     assert_eq!(t!(h.device_minor()), Some(2));
 
-    h = Header::new_ustar();
-    t!(h.set_device_major(1));
-    t!(h.set_device_minor(2));
-    assert_eq!(t!(h.device_major()), Some(1));
-    assert_eq!(t!(h.device_minor()), Some(2));
+    let mut raw: UstarHeader = unsafe { mem::zeroed() };
+    raw.magic = *b"ustar\0";
+    raw.version = *b"00";
+    raw.dev_minor[0] = 0x7f;
+    raw.dev_major[0] = 0x7f;
+    assert!(raw.as_header().device_major().is_err());
+    assert!(raw.as_header().device_minor().is_err());
 
-    h.as_ustar_mut().unwrap().dev_minor[0] = 0x7f;
-    h.as_ustar_mut().unwrap().dev_major[0] = 0x7f;
-    assert!(h.device_major().is_err());
-    assert!(h.device_minor().is_err());
+    raw.dev_minor[0] = b'g';
+    raw.dev_major[0] = b'h';
+    assert!(raw.as_header().device_major().is_err());
+    assert!(raw.as_header().device_minor().is_err());
 
-    h.as_ustar_mut().unwrap().dev_minor[0] = b'g';
-    h.as_ustar_mut().unwrap().dev_major[0] = b'h';
-    assert!(h.device_major().is_err());
-    assert!(h.device_minor().is_err());
-
-    h = Header::new_old();
-    assert_eq!(t!(h.device_major()), None);
-    assert_eq!(t!(h.device_minor()), None);
-    assert!(h.set_device_major(1).is_err());
-    assert!(h.set_device_minor(1).is_err());
+    let h = old_header();
+    assert_eq!(t!(h.as_header().device_major()), None);
+    assert_eq!(t!(h.as_header().device_minor()), None);
 }
 
 #[test]
 fn set_path() {
-    let mut h = Header::new_gnu();
+    let mut h = Header::new_ustar();
     t!(h.set_path("foo"));
     assert_eq!(t!(h.path()).to_str(), Some("foo"));
     t!(h.set_path("foo/"));
@@ -156,7 +166,8 @@ fn set_path() {
 
     assert!(h.set_path(&long_name).is_err());
     assert!(h.set_path(&medium1).is_err());
-    assert!(h.set_path(&medium2).is_err());
+    t!(h.set_path(&medium2));
+    assert_eq!(t!(h.path()).to_str(), Some(&medium2[..]));
     assert!(h.set_path("\0").is_err());
 
     assert!(h.set_path("..").is_err());
@@ -219,24 +230,35 @@ fn set_metadata_deterministic() {
 
 #[test]
 fn extended_numeric_format() {
+    let mut header = Header::new_ustar();
+    header.set_size(42);
+    assert_eq!(
+        header.as_old().size,
+        [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]
+    );
+    header.set_size(8589934593);
+    assert_eq!(
+        header.as_old().size,
+        [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 1]
+    );
+    header.set_size(44);
+    assert_eq!(
+        header.as_old().size,
+        [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 52, 0]
+    );
+
     let mut h: GnuHeader = unsafe { mem::zeroed() };
-    h.as_header_mut().set_size(42);
-    assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 50, 0]);
-    h.as_header_mut().set_size(8589934593);
-    assert_eq!(h.size, [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 1]);
-    h.as_header_mut().set_size(44);
-    assert_eq!(h.size, [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 52, 0]);
     h.size = [0x80, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0, 0];
     assert_eq!(h.as_header().entry_size().unwrap(), 0x0200000000);
     h.size = [48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 51, 0];
     assert_eq!(h.as_header().entry_size().unwrap(), 43);
 
-    h.as_header_mut().set_gid(42);
-    assert_eq!(h.gid, [48, 48, 48, 48, 48, 53, 50, 0]);
-    assert_eq!(h.as_header().gid().unwrap(), 42);
-    h.as_header_mut().set_gid(0x7fffffffffffffff);
-    assert_eq!(h.gid, [0xff; 8]);
-    assert_eq!(h.as_header().gid().unwrap(), 0x7fffffffffffffff);
+    header.set_gid(42);
+    assert_eq!(header.as_old().gid, [48, 48, 48, 48, 48, 53, 50, 0]);
+    assert_eq!(header.gid().unwrap(), 42);
+    header.set_gid(0x7fffffffffffffff);
+    assert_eq!(header.as_old().gid, [0xff; 8]);
+    assert_eq!(header.gid().unwrap(), 0x7fffffffffffffff);
     h.uid = [0x80, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78];
     assert_eq!(h.as_header().uid().unwrap(), 0x12345678);
 
@@ -255,7 +277,7 @@ fn extended_numeric_format() {
 
 #[test]
 fn byte_slice_conversion() {
-    let h = Header::new_gnu();
+    let h = Header::new_ustar();
     let b: &[u8] = h.as_bytes();
     let b_conv: &[u8] = Header::from_byte_slice(h.as_bytes()).as_bytes();
     assert_eq!(b, b_conv);


### PR DESCRIPTION
This removes our GNU-style archive writing pathways and replaces them with pax-only paths. The idea here is to make it harder to write "chimera" archives that contain both GNU and pax features, as well as align ourselves with our primary consumer (uv, which per PEP 625 is required to write pax-compatible sdists).

I'm not 100% confident in this yet; I'd like to add some cross-implementation regression tests.

Signed-off-by: William Woodruff <william@yossarian.net>