### PR TITLE
Remove filetime dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 name = "astral-tokio-tar"
 version = "0.6.2"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
@@ -88,18 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,17 +115,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 
 [target."cfg(unix)".dependencies]
-xattr = { version = "1.0", optional = true }
 libc = "0.2"
+rustix = { version = "0.38", features = ["fs"] }
+xattr = { version = "1.0", optional = true }
 
 [features]
 default = ["xattr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-filetime = "0.2"
 futures-core = "0.3"
 portable-atomic = "1"
 rustc-hash = "2.1.0"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,7 +2,6 @@ use crate::fs::normalize;
 use crate::{
     error::TarError, header::bytes2path, other, pax::pax_extensions, Archive, Header, PaxExtensions,
 };
-use filetime::{self, FileTime};
 use rustc_hash::FxHashSet;
 use std::{
     borrow::Cow,
@@ -10,17 +9,135 @@ use std::{
     collections::VecDeque,
     convert::TryFrom,
     fmt,
+    fs::FileTimes,
     io::{Error, ErrorKind, SeekFrom},
     marker,
     path::{Component, Path, PathBuf},
     pin::Pin,
     task::{Context, Poll},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::{
     fs,
     fs::{remove_file, OpenOptions},
     io::{self, AsyncRead as Read, AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
+
+fn set_file_times(file: &std::fs::File, mtime: SystemTime) -> io::Result<()> {
+    file.set_times(FileTimes::new().set_accessed(mtime).set_modified(mtime))
+}
+
+#[cfg(windows)]
+fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
+        .open(dst)?;
+    set_file_times(&file, mtime)
+}
+
+#[cfg(target_os = "redox")]
+fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(dst)?;
+    set_file_times(&file, mtime)
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "android",
+        target_os = "aix",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "haiku"
+    )
+))]
+fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
+    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+
+    let duration = mtime
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime predates the Unix epoch"))?;
+    let seconds = libc::time_t::try_from(duration.as_secs())
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime exceeds platform limits"))?;
+    let timestamp = libc::timespec {
+        tv_sec: seconds,
+        tv_nsec: duration.subsec_nanos() as _,
+    };
+    let timestamps = [timestamp, timestamp];
+    let dst = CString::new(dst.as_os_str().as_bytes())?;
+    let result = unsafe {
+        libc::utimensat(
+            libc::AT_FDCWD,
+            dst.as_ptr(),
+            timestamps.as_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(Error::last_os_error())
+    }
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "redox",
+        target_os = "emscripten",
+        target_os = "android",
+        target_os = "aix",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "haiku"
+    ))
+))]
+fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
+    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+
+    let duration = mtime
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime predates the Unix epoch"))?;
+    let seconds = libc::time_t::try_from(duration.as_secs())
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime exceeds platform limits"))?;
+    let timestamp = libc::timeval {
+        tv_sec: seconds,
+        tv_usec: duration.subsec_micros() as _,
+    };
+    let timestamps = [timestamp, timestamp];
+    let dst = CString::new(dst.as_os_str().as_bytes())?;
+    let result = unsafe { libc::lutimes(dst.as_ptr(), timestamps.as_ptr()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(Error::last_os_error())
+    }
+}
+
+#[cfg(any(all(unix, target_os = "emscripten"), all(not(unix), not(windows))))]
+fn set_symlink_file_times(_: &Path, _: SystemTime) -> io::Result<()> {
+    Err(Error::new(
+        ErrorKind::Unsupported,
+        "setting timestamps on symlinks is not supported on this platform",
+    ))
+}
 
 /// A read-only view into an entry of an archive.
 ///
@@ -582,17 +699,22 @@ impl<R: Read + Unpin> EntryFields<R> {
 
     /// Returns access to the header of this entry in the archive.
     async fn unpack(&mut self, target_base: Option<&Path>, dst: &Path) -> io::Result<Unpacked> {
-        fn get_mtime(header: &Header) -> Option<FileTime> {
-            header.mtime().ok().map(|mtime| {
-                // For some more information on this see the comments in
-                // `Header::fill_platform_from`, but the general idea is that
-                // we're trying to avoid 0-mtime files coming out of archives
-                // since some tools don't ingest them well. Perhaps one day
-                // when Cargo stops working with 0-mtime archives we can remove
-                // this.
-                let mtime = if mtime == 0 { 1 } else { mtime };
-                FileTime::from_unix_time(mtime as i64, 0)
-            })
+        fn get_mtime(header: &Header) -> io::Result<Option<SystemTime>> {
+            let Ok(mtime) = header.mtime() else {
+                return Ok(None);
+            };
+
+            // For some more information on this see the comments in
+            // `Header::fill_platform_from`, but the general idea is that
+            // we're trying to avoid 0-mtime files coming out of archives
+            // since some tools don't ingest them well. Perhaps one day
+            // when Cargo stops working with 0-mtime archives we can remove
+            // this.
+            let mtime = if mtime == 0 { 1 } else { mtime };
+            UNIX_EPOCH
+                .checked_add(Duration::from_secs(mtime))
+                .map(Some)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "mtime exceeds system limits"))
         }
 
         let kind = self.header.entry_type();
@@ -714,8 +836,8 @@ impl<R: Read + Unpin> EntryFields<R> {
                     }
                 }?;
                 if self.preserve_mtime {
-                    if let Some(mtime) = get_mtime(&self.header) {
-                        filetime::set_symlink_file_times(dst, mtime, mtime).map_err(|e| {
+                    if let Some(mtime) = get_mtime(&self.header)? {
+                        set_symlink_file_times(dst, mtime).map_err(|e| {
                             TarError::new(format!("failed to set mtime for `{}`", dst.display()), e)
                         })?;
                     }
@@ -835,10 +957,12 @@ impl<R: Read + Unpin> EntryFields<R> {
         })?;
 
         if self.preserve_mtime {
-            if let Some(mtime) = get_mtime(&self.header) {
-                filetime::set_file_times(dst, mtime, mtime).map_err(|e| {
+            if let Some(mtime) = get_mtime(&self.header)? {
+                let file = f.into_std().await;
+                set_file_times(&file, mtime).map_err(|e| {
                     TarError::new(format!("failed to set mtime for `{}`", dst.display()), e)
                 })?;
+                f = fs::File::from_std(file);
             }
         }
         if self.preserve_permissions {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -52,87 +52,35 @@ fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
     set_file_times(&file, mtime)
 }
 
-#[cfg(all(
-    unix,
-    any(
-        target_os = "android",
-        target_os = "aix",
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "haiku"
-    )
-))]
+#[cfg(all(unix, not(any(target_os = "redox", target_os = "emscripten"))))]
 fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
-    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+    use rustix::fs::{utimensat, AtFlags, Timespec, Timestamps, CWD};
 
     let duration = mtime
         .duration_since(UNIX_EPOCH)
         .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime predates the Unix epoch"))?;
-    let seconds = libc::time_t::try_from(duration.as_secs())
+    let seconds = duration
+        .as_secs()
+        .try_into()
         .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime exceeds platform limits"))?;
-    let timestamp = libc::timespec {
-        tv_sec: seconds,
-        tv_nsec: duration.subsec_nanos() as _,
+    let nanoseconds = duration.subsec_nanos().into();
+    let timestamps = Timestamps {
+        last_access: Timespec {
+            tv_sec: seconds,
+            tv_nsec: nanoseconds,
+        },
+        last_modification: Timespec {
+            tv_sec: seconds,
+            tv_nsec: nanoseconds,
+        },
     };
-    let timestamps = [timestamp, timestamp];
-    let dst = CString::new(dst.as_os_str().as_bytes())?;
-    let result = unsafe {
-        libc::utimensat(
-            libc::AT_FDCWD,
-            dst.as_ptr(),
-            timestamps.as_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(Error::last_os_error())
-    }
-}
-
-#[cfg(all(
-    unix,
-    not(any(
-        target_os = "redox",
-        target_os = "emscripten",
-        target_os = "android",
-        target_os = "aix",
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "haiku"
-    ))
-))]
-fn set_symlink_file_times(dst: &Path, mtime: SystemTime) -> io::Result<()> {
-    use std::{ffi::CString, os::unix::ffi::OsStrExt};
-
-    let duration = mtime
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime predates the Unix epoch"))?;
-    let seconds = libc::time_t::try_from(duration.as_secs())
-        .map_err(|_| Error::new(ErrorKind::InvalidData, "mtime exceeds platform limits"))?;
-    let timestamp = libc::timeval {
-        tv_sec: seconds,
-        tv_usec: duration.subsec_micros() as _,
-    };
-    let timestamps = [timestamp, timestamp];
-    let dst = CString::new(dst.as_os_str().as_bytes())?;
-    let result = unsafe { libc::lutimes(dst.as_ptr(), timestamps.as_ptr()) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(Error::last_os_error())
-    }
+    utimensat(CWD, dst, &timestamps, AtFlags::SYMLINK_NOFOLLOW).map_err(Into::into)
 }
 
 #[cfg(any(all(unix, target_os = "emscripten"), all(not(unix), not(windows))))]
 fn set_symlink_file_times(_: &Path, _: SystemTime) -> io::Result<()> {
+    // NOTE: This imitates `filetime`, which explicitly fails on these platforms.
+    // See: <https://docs.rs/crate/filetime/0.2.29/source/src/wasm.rs#7>
     Err(Error::new(
         ErrorKind::Unsupported,
         "setting timestamps on symlinks is not supported on this platform",

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,6 +1,5 @@
 extern crate tokio_tar as async_tar;
 
-extern crate filetime;
 extern crate tempfile;
 #[cfg(all(unix, feature = "xattr"))]
 extern crate xattr;
@@ -8,6 +7,7 @@ extern crate xattr;
 use std::{
     io::Cursor,
     path::{Path, PathBuf},
+    time::UNIX_EPOCH,
 };
 use tokio::{
     fs::{self, File},
@@ -16,7 +16,6 @@ use tokio::{
 use tokio_stream::*;
 
 use async_tar::{Archive, ArchiveBuilder, Builder, EntryType, Header};
-use filetime::FileTime;
 use tempfile::{Builder as TempBuilder, TempDir};
 
 macro_rules! t {
@@ -797,12 +796,12 @@ async fn file_times() {
     t!(ar.unpack(td.path()).await);
 
     let meta = fs::metadata(td.path().join("a")).await.unwrap();
-    let mtime = FileTime::from_last_modification_time(&meta);
-    let atime = FileTime::from_last_access_time(&meta);
-    assert_eq!(mtime.unix_seconds(), 1_000_000_000);
-    assert_eq!(mtime.nanoseconds(), 0);
-    assert_eq!(atime.unix_seconds(), 1_000_000_000);
-    assert_eq!(atime.nanoseconds(), 0);
+    let mtime = t!(t!(meta.modified()).duration_since(UNIX_EPOCH));
+    let atime = t!(t!(meta.accessed()).duration_since(UNIX_EPOCH));
+    assert_eq!(mtime.as_secs(), 1_000_000_000);
+    assert_eq!(mtime.subsec_nanos(), 0);
+    assert_eq!(atime.as_secs(), 1_000_000_000);
+    assert_eq!(atime.subsec_nanos(), 0);
 }
 
 #[tokio::test]
@@ -874,8 +873,8 @@ async fn unpack_links() {
     let md = t!(fs::symlink_metadata(td.path().join("lnk")).await);
     assert!(md.file_type().is_symlink());
 
-    let mtime = FileTime::from_last_modification_time(&md);
-    assert_eq!(mtime.unix_seconds(), 1448291033);
+    let mtime = t!(t!(md.modified()).duration_since(UNIX_EPOCH));
+    assert_eq!(mtime.as_secs(), 1448291033);
 
     assert_eq!(
         &*t!(fs::read_link(td.path().join("lnk")).await),


### PR DESCRIPTION
This dependency is deprecated. I've replaced it with `std::fs::FileTimes` + `rustix` where needed.

~~WIP, not sure if we should land this yet. I don't like that it needs unsafe, there should be a better way to do this?~~