### PR TITLE
Create GitHub release in publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: crates-io
+    outputs:
+      prerelease: ${{ steps.version.outputs.prerelease }}
 
     permissions:
       id-token: write # for Trusted Publishing to crates.io
@@ -25,6 +27,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check tag matches crate version
+        id: version
+        run: |
+          crate_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          tag_version="${GITHUB_REF_NAME#v}"
+
+          if [[ "${tag_version}" != "${crate_version}" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match crate version ${crate_version}"
+            exit 1
+          fi
+
+          if [[ "${crate_version%%+*}" == *-* ]]; then
+            echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
@@ -32,3 +51,24 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: "${{ steps.auth.outputs.token }}"
+
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish
+
+    permissions:
+      contents: write # for creating GitHub releases
+
+    steps:
+      - name: Create GitHub release
+        run: |
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            gh release create "${GITHUB_REF_NAME}" --verify-tag --title "${GITHUB_REF_NAME}" --generate-notes --prerelease
+          else
+            gh release create "${GITHUB_REF_NAME}" --verify-tag --title "${GITHUB_REF_NAME}" --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PRERELEASE: ${{ needs.publish.outputs.prerelease }}


### PR DESCRIPTION
Automate the last step in publishing, so that pushing a tag does everything required.

The generated GitHub release notes aren't the prettiest, but sufficient for a project of this size and change frequency.